### PR TITLE
feat: Lumyn Pro subscription (.97/month)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ apps/web/.env.local
 
 # Local Netlify folder
 .netlify
+.worktrees/

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -21,6 +21,8 @@
   # Stripe Live Keys - ADDED 2025-11-11
   VITE_STRIPE_PUBLISHABLE_KEY = "pk_live_51SGaypKQHOT2DNgNdJJ0nZNP2zL7iK3Gb4D3ai4L6poMV6CD0mRSvNIfDpdbA3nXhgP0avW4jPlOsUXZKkuBy50s00unH0hCzd"
   VITE_V4_ENABLED = "false"
+  # Lumyn Pro subscription price ID - ADDED 2026-03-20
+  VITE_LUMYN_PRO_PRICE_ID = "price_1TDCy4KQHOT2DNgNv5aINeKq"
 
 # Redirect old domain to new primary domain
 [[redirects]]

--- a/apps/web/src/components/LumynChatFab.tsx
+++ b/apps/web/src/components/LumynChatFab.tsx
@@ -84,7 +84,11 @@ export function LumynChatFab() {
       return;
     }
     const result = await purchaseTier("lumyn-pro", { priceId, fullName: "", dob: "" });
-    if (result.redirectUrl) window.location.href = result.redirectUrl;
+    if (result.redirectUrl) {
+      window.location.href = result.redirectUrl;
+    } else {
+      await refetchEntitlement();
+    }
   };
 
   const handleSend = async () => {

--- a/apps/web/src/components/LumynChatFab.tsx
+++ b/apps/web/src/components/LumynChatFab.tsx
@@ -64,6 +64,7 @@ export function LumynChatFab() {
         setChatMessages(messages as ChatMessage[]);
       }
       setConversationId(conversation.id);
+      setPaywallHit(false);
     } finally {
       setIsProcessing(false);
     }
@@ -74,6 +75,7 @@ export function LumynChatFab() {
     setChatMessages([]);
     setConversationId(undefined);
     setShowCrisisBanner(false);
+    setPaywallHit(false);
   };
 
   const handleUpgrade = async () => {

--- a/apps/web/src/components/LumynChatFab.tsx
+++ b/apps/web/src/components/LumynChatFab.tsx
@@ -1,10 +1,16 @@
 import { useState, useEffect } from "react";
-import { Sparkles, X, AlertTriangle } from "lucide-react";
+import { Sparkles, X, AlertTriangle, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { LumenChat, ChatMessage } from "@/features/capture/components/LumenChat";
 import { callLumynChat } from "@/services/lumynApi";
 import { buildLumynContext } from "@/lib/lumynContext";
 import { useToast } from "@/components/ui/use-toast";
+import { useLumynEntitlement } from "@/hooks/useLumynEntitlement";
+import { LumynThreadList } from "@/components/LumynThreadList";
+import { LumynPaywallCard } from "@/components/LumynPaywallCard";
+import { supabase } from "@/integrations/supabase/client";
+import { isNative } from "@/lib/platform";
+import type { LumynConversation } from "@/types/lumyn";
 
 const CHAT_STORAGE_KEY = "vyberology_lumyn_chat";
 
@@ -30,6 +36,10 @@ export function LumynChatFab() {
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
   const [showCrisisBanner, setShowCrisisBanner] = useState(false);
 
+  const { isPro, messagesUsed, refetch: refetchEntitlement } = useLumynEntitlement();
+  const [showThreadList, setShowThreadList] = useState(false);
+  const [paywallHit, setPaywallHit] = useState(false);
+
   // Persist chat messages
   useEffect(() => {
     try {
@@ -39,6 +49,43 @@ export function LumynChatFab() {
       /* ignore */
     }
   }, [chatMessages]);
+
+  const handleSelectThread = async (conversation: LumynConversation) => {
+    setShowThreadList(false);
+    setIsProcessing(true);
+    try {
+      const { data: messages } = await supabase
+        .from("lumyn_messages")
+        .select("role, content")
+        .eq("conversation_id", conversation.id)
+        .order("created_at", { ascending: true });
+
+      if (messages) {
+        setChatMessages(messages as ChatMessage[]);
+      }
+      setConversationId(conversation.id);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleNewThread = () => {
+    setShowThreadList(false);
+    setChatMessages([]);
+    setConversationId(undefined);
+    setShowCrisisBanner(false);
+  };
+
+  const handleUpgrade = async () => {
+    const { purchaseTier } = await import("@/services/purchase");
+    const priceId = import.meta.env.VITE_LUMYN_PRO_PRICE_ID ?? "";
+    if (isNative()) {
+      alert("Please visit vyberology.com to upgrade to Lumyn Pro.");
+      return;
+    }
+    const result = await purchaseTier("lumyn-pro", { priceId, fullName: "", dob: "" });
+    if (result.redirectUrl) window.location.href = result.redirectUrl;
+  };
 
   const handleSend = async () => {
     if (!chatInput.trim()) return;
@@ -60,6 +107,14 @@ export function LumynChatFab() {
         vyberologyContext: inputs,
       });
       setConversationId(response.conversationId);
+
+      if (response.paywall) {
+        setPaywallHit(true);
+        return; // Do not append any message to chatMessages
+      }
+      // Clear paywall state if user is now Pro
+      setPaywallHit(false);
+
       setShowCrisisBanner(response.client_directives.crisis_banner);
       setChatMessages((prev) => [
         ...prev,
@@ -98,13 +153,33 @@ export function LumynChatFab() {
       {isOpen && (
         <div className="fixed bottom-20 right-4 sm:right-6 z-50 w-[calc(100vw-2rem)] sm:w-[400px]">
           <div className="relative">
-            {/* Close button */}
-            <button
-              onClick={() => setIsOpen(false)}
-              className="absolute -top-3 -right-3 z-10 w-7 h-7 rounded-full bg-vy-charcoal text-vy-parchment flex items-center justify-center shadow-lg hover:bg-vy-charcoal/80 transition-colors"
-            >
-              <X className="w-4 h-4" />
-            </button>
+            {/* Panel header */}
+            <div className="absolute -top-3 right-0 left-0 flex justify-between items-center px-1 z-10">
+              {/* Thread list toggle */}
+              <button
+                onClick={() => setShowThreadList((prev) => !prev)}
+                className="w-7 h-7 rounded-full bg-vy-charcoal text-vy-parchment flex items-center justify-center shadow-lg hover:bg-vy-charcoal/80 transition-colors"
+                title="Conversations"
+              >
+                <MessageSquare className="w-3.5 h-3.5" />
+              </button>
+
+              {/* Free message counter */}
+              {!isPro && (
+                <span className="text-[10px] text-vy-charcoal/40 font-sans">
+                  {messagesUsed} / 10 free messages
+                </span>
+              )}
+
+              {/* Close button */}
+              <button
+                onClick={() => setIsOpen(false)}
+                className="w-7 h-7 rounded-full bg-vy-charcoal text-vy-parchment flex items-center justify-center shadow-lg hover:bg-vy-charcoal/80 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
             <LumenChat
               messages={chatMessages}
               inputValue={chatInput}
@@ -112,6 +187,33 @@ export function LumynChatFab() {
               onSend={handleSend}
               isProcessing={isProcessing}
             />
+
+            {/* Inline paywall card */}
+            {paywallHit && (
+              <LumynPaywallCard />
+            )}
+
+            {/* Thread list drawer */}
+            {showThreadList && (
+              <div className="absolute inset-0 z-10 bg-vy-parchment rounded-2xl overflow-hidden flex flex-col">
+                <div className="flex items-center justify-between px-4 py-3 border-b border-vy-charcoal/10">
+                  <span className="text-sm font-semibold text-vy-charcoal">Conversations</span>
+                  <button
+                    onClick={() => setShowThreadList(false)}
+                    className="text-vy-charcoal/40 hover:text-vy-charcoal"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                <LumynThreadList
+                  currentConversationId={conversationId}
+                  isPro={isPro}
+                  onSelectThread={handleSelectThread}
+                  onNewThread={handleNewThread}
+                  onUpgrade={handleUpgrade}
+                />
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/apps/web/src/components/LumynPaywallCard.tsx
+++ b/apps/web/src/components/LumynPaywallCard.tsx
@@ -1,0 +1,52 @@
+// apps/web/src/components/LumynPaywallCard.tsx
+import { Crown } from 'lucide-react'
+import { purchaseTier } from '@/services/purchase'
+import { isNative } from '@/lib/platform'
+
+const LUMYN_PRO_PRICE_ID = import.meta.env.VITE_LUMYN_PRO_PRICE_ID ?? ''
+
+interface Props {
+  onUpgradeStart?: () => void
+}
+
+export function LumynPaywallCard({ onUpgradeStart }: Props) {
+  const handleUpgrade = async () => {
+    onUpgradeStart?.()
+
+    if (isNative()) {
+      // Native subscription path is not yet enabled for Lumyn Pro
+      alert('Please visit vyberology.com to upgrade to Lumyn Pro.')
+      return
+    }
+
+    const result = await purchaseTier('lumyn-pro', {
+      priceId: LUMYN_PRO_PRICE_ID,
+      fullName: '',
+      dob: '',
+    })
+
+    if (result.redirectUrl) {
+      window.location.href = result.redirectUrl
+    }
+  }
+
+  return (
+    <div className="mx-2 my-1 rounded-2xl border border-vy-gold/30 bg-gradient-to-br from-vy-gold/5 to-amber-50/50 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Crown className="w-4 h-4 text-vy-gold shrink-0" />
+        <span className="text-sm font-semibold text-vy-charcoal">
+          You've used your 10 free messages with Lumyn.
+        </span>
+      </div>
+      <p className="text-xs text-vy-charcoal/60 mb-3 pl-6">
+        Upgrade to Pro for unlimited conversations, full memory, and all four modes — $14.97/month.
+      </p>
+      <button
+        onClick={handleUpgrade}
+        className="w-full py-2.5 rounded-xl bg-gradient-to-r from-vy-gold to-amber-500 text-white text-sm font-semibold hover:opacity-90 transition-opacity"
+      >
+        Upgrade to Lumyn Pro
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/LumynThreadList.tsx
+++ b/apps/web/src/components/LumynThreadList.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/LumynThreadList.tsx
+import { useEffect, useState, useCallback } from 'react'
+import { Plus, MessageSquare, Crown } from 'lucide-react'
+import { supabase } from '@/integrations/supabase/client'
+import type { LumynConversation } from '@/types/lumyn'
+
+interface Props {
+  currentConversationId: string | undefined
+  isPro: boolean
+  onSelectThread: (conversation: LumynConversation) => void
+  onNewThread: () => void
+  onUpgrade: () => void
+}
+
+export function LumynThreadList({
+  currentConversationId,
+  isPro,
+  onSelectThread,
+  onNewThread,
+  onUpgrade,
+}: Props) {
+  const [threads, setThreads] = useState<LumynConversation[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const loadThreads = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+
+      const query = supabase
+        .from('lumyn_conversations')
+        .select('id, title, mode, status, created_at, ended_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+
+      if (!isPro) {
+        query.limit(1)
+      } else {
+        query.limit(10)
+      }
+
+      const { data, error } = await query
+      if (!error && data) setThreads(data as LumynConversation[])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isPro])
+
+  useEffect(() => { loadThreads() }, [loadThreads])
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* New conversation button */}
+      <button
+        onClick={onNewThread}
+        className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-vy-charcoal hover:bg-vy-charcoal/5 transition-colors border-b border-vy-charcoal/10"
+      >
+        <Plus className="w-4 h-4" />
+        New conversation
+      </button>
+
+      {/* Thread list */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="p-4 text-center text-xs text-vy-charcoal/40">Loading…</div>
+        ) : threads.length === 0 ? (
+          <div className="p-4 text-center text-xs text-vy-charcoal/40">No conversations yet.</div>
+        ) : (
+          threads.map((thread) => {
+            const title = thread.title || `Conversation · ${formatDate(thread.created_at)}`
+            const isActive = thread.id === currentConversationId
+            return (
+              <button
+                key={thread.id}
+                onClick={() => onSelectThread(thread)}
+                className={`w-full text-left px-4 py-3 border-b border-vy-charcoal/[0.06] transition-colors hover:bg-vy-charcoal/5 ${
+                  isActive ? 'bg-vy-gold/10' : ''
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-0.5">
+                  <MessageSquare className="w-3 h-3 text-vy-charcoal/30 shrink-0" />
+                  <span className="text-sm font-medium text-vy-charcoal truncate">{title}</span>
+                </div>
+                <div className="flex items-center gap-2 pl-5">
+                  <span className="text-[10px] uppercase tracking-wide text-vy-charcoal/30">
+                    {thread.mode}
+                  </span>
+                  <span className="text-[10px] text-vy-charcoal/30">·</span>
+                  <span className="text-[10px] text-vy-charcoal/30">
+                    {formatDate(thread.created_at)}
+                  </span>
+                </div>
+              </button>
+            )
+          })
+        )}
+      </div>
+
+      {/* Pro upgrade banner — free users only */}
+      {!isPro && (
+        <div className="border-t border-vy-charcoal/10 p-4">
+          <p className="text-xs text-vy-charcoal/50 mb-2">
+            Unlock full conversation history with Pro.
+          </p>
+          <button
+            onClick={onUpgrade}
+            className="flex items-center gap-1.5 w-full justify-center py-2 rounded-lg bg-gradient-to-r from-vy-gold to-amber-500 text-white text-xs font-semibold"
+          >
+            <Crown className="w-3 h-3" />
+            Upgrade to Lumyn Pro
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/LumynThreadList.tsx
+++ b/apps/web/src/components/LumynThreadList.tsx
@@ -28,16 +28,16 @@ export function LumynThreadList({
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) return
 
-      const query = supabase
+      let query = supabase
         .from('lumyn_conversations')
         .select('id, title, mode, status, created_at, ended_at')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false })
 
       if (!isPro) {
-        query.limit(1)
+        query = query.limit(1)
       } else {
-        query.limit(10)
+        query = query.limit(10)
       }
 
       const { data, error } = await query

--- a/apps/web/src/hooks/useLumynEntitlement.ts
+++ b/apps/web/src/hooks/useLumynEntitlement.ts
@@ -1,0 +1,55 @@
+// apps/web/src/hooks/useLumynEntitlement.ts
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/integrations/supabase/client'
+
+export type LumynEntitlement = {
+  isPro: boolean
+  messagesUsed: number
+  isLoading: boolean
+  refetch: () => Promise<void>
+}
+
+export function useLumynEntitlement(): LumynEntitlement {
+  const [isPro, setIsPro] = useState(false)
+  const [messagesUsed, setMessagesUsed] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetch = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        setIsPro(false)
+        setMessagesUsed(0)
+        return
+      }
+
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('lumyn_pro, lumyn_pro_until, lumyn_messages_used')
+        .eq('user_id', user.id)
+        .maybeSingle()
+
+      if (error || !data) {
+        setIsPro(false)
+        setMessagesUsed(0)
+        return
+      }
+
+      const resolvedPro =
+        data.lumyn_pro &&
+        (data.lumyn_pro_until === null || new Date(data.lumyn_pro_until) > new Date())
+
+      setIsPro(resolvedPro)
+      setMessagesUsed(data.lumyn_messages_used ?? 0)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
+
+  return { isPro, messagesUsed, isLoading, refetch: fetch }
+}

--- a/apps/web/src/hooks/useLumynEntitlement.ts
+++ b/apps/web/src/hooks/useLumynEntitlement.ts
@@ -1,6 +1,7 @@
 // apps/web/src/hooks/useLumynEntitlement.ts
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/integrations/supabase/client'
+import { resolveClientLumynEntitlement } from '@/lib/lumynEntitlement'
 
 export type LumynEntitlement = {
   isPro: boolean
@@ -36,9 +37,10 @@ export function useLumynEntitlement(): LumynEntitlement {
         return
       }
 
-      const resolvedPro =
-        data.lumyn_pro &&
-        (data.lumyn_pro_until === null || new Date(data.lumyn_pro_until) > new Date())
+      const resolvedPro = resolveClientLumynEntitlement({
+        lumyn_pro: data.lumyn_pro,
+        lumyn_pro_until: data.lumyn_pro_until,
+      })
 
       setIsPro(resolvedPro)
       setMessagesUsed(data.lumyn_messages_used ?? 0)

--- a/apps/web/src/lib/lumynEntitlement.ts
+++ b/apps/web/src/lib/lumynEntitlement.ts
@@ -1,0 +1,16 @@
+// apps/web/src/lib/lumynEntitlement.ts
+
+/**
+ * Shared client-side entitlement resolver.
+ * Must match the server-side resolveLumynEntitlement in supabase/functions/lumyn-chat/db.ts.
+ * If the resolution rule changes, update both.
+ */
+export function resolveClientLumynEntitlement(profile: {
+  lumyn_pro: boolean
+  lumyn_pro_until: string | null
+}): boolean {
+  return (
+    profile.lumyn_pro &&
+    (profile.lumyn_pro_until === null || new Date(profile.lumyn_pro_until) > new Date())
+  )
+}

--- a/apps/web/src/pages/PaymentSuccess.tsx
+++ b/apps/web/src/pages/PaymentSuccess.tsx
@@ -3,13 +3,18 @@ import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { ArrowLeft, Home, Check, Sparkles } from "lucide-react";
 import { Footer } from "@/components/Footer";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLumynEntitlement } from "@/hooks/useLumynEntitlement";
+import { useToast } from "@/hooks/use-toast";
 
 export default function PaymentSuccess() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { credits, refreshCredits } = useAuth();
+  const { refetch: refetchEntitlement } = useLumynEntitlement();
+  const { toast } = useToast();
   const sessionId = searchParams.get("session_id");
   const tier = searchParams.get("tier");
+  const upgraded = searchParams.get("upgraded") === "true";
   const [creditsLoading, setCreditsLoading] = useState(true);
 
   useEffect(() => {
@@ -18,12 +23,32 @@ export default function PaymentSuccess() {
       .finally(() => setCreditsLoading(false));
   }, [refreshCredits]);
 
+  useEffect(() => {
+    if (upgraded) {
+      refetchEntitlement();
+    }
+  }, [upgraded, refetchEntitlement]);
+
+  useEffect(() => {
+    if (upgraded && tier === "lumyn-pro") {
+      const timer = setTimeout(() => {
+        toast({
+          title: "Welcome to Lumyn Pro",
+          description: "Enjoy unlimited conversations.",
+        });
+      }, 800);
+      return () => clearTimeout(timer);
+    }
+  }, [upgraded, tier, toast]);
+
   const tierLabel =
     tier === "full-vybe"
       ? "Full VYBE Reading"
       : tier === "lyf-path"
         ? "Lyf Path Reading"
-        : null;
+        : tier === "lumyn-pro"
+          ? "Lumyn Pro"
+          : null;
 
   return (
     <div className="min-h-screen flex flex-col bg-vy-parchment grain">
@@ -57,95 +82,130 @@ export default function PaymentSuccess() {
           </h1>
           <div className="vy-divider max-w-[80px] mx-auto mb-4" />
 
-          {tierLabel ? (
-            <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
-              Your <span className="font-medium text-vy-charcoal/70">{tierLabel}</span> credit is ready. Head to Lyf Path to generate your reading.
-            </p>
-          ) : (
-            <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
-              Your credits have been added to your account.
-            </p>
-          )}
-
-          {/* Credits Display */}
-          <div className="p-6 rounded-2xl border border-vy-gold/20 bg-white/50 backdrop-blur-sm mb-8">
-            <div className="flex items-center justify-center gap-2 mb-2">
-              <Sparkles className="w-5 h-5 text-vy-gold" />
-              <span className="font-sans text-xs font-semibold uppercase tracking-[0.12em] text-vy-charcoal/50">
-                Your Balance
-              </span>
-            </div>
-            <p className="font-display text-4xl font-bold text-vy-charcoal mb-1">
-              {creditsLoading ? "..." : credits}
-            </p>
-            <p className="font-sans text-sm text-vy-charcoal/40">
-              credit{credits !== 1 ? "s" : ""} available
-            </p>
-          </div>
-
-          {/* What's Next */}
-          <div className="p-6 rounded-2xl border border-vy-charcoal/[0.08] bg-white/50 backdrop-blur-sm mb-8 text-left">
-            <h3 className="font-display text-lg font-semibold text-vy-charcoal mb-4">
-              What's Next
-            </h3>
-            <ul className="space-y-3">
-              <li className="flex items-start gap-3">
-                <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
-                <span className="font-sans text-sm text-vy-charcoal/60">
-                  {tierLabel
-                    ? `Your ${tierLabel} credit is ready to use`
-                    : "Your credits are ready to use across all reading types"}
-                </span>
-              </li>
-              <li className="flex items-start gap-3">
-                <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
-                <span className="font-sans text-sm text-vy-charcoal/60">
-                  A confirmation email has been sent to your address
-                </span>
-              </li>
-              <li className="flex items-start gap-3">
-                <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
-                <span className="font-sans text-sm text-vy-charcoal/60">
-                  Your credits never expire — use them whenever you're ready
-                </span>
-              </li>
-            </ul>
-          </div>
-
-          {/* Transaction ID */}
-          {sessionId && (
-            <div className="p-4 rounded-xl bg-vy-charcoal/[0.03] mb-8">
-              <p className="font-sans text-xs text-vy-charcoal/40">
-                Transaction ID:{" "}
-                <span className="font-mono text-[11px] text-vy-charcoal/30">
-                  {sessionId}
-                </span>
+          {tier === "lumyn-pro" ? (
+            <>
+              <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
+                Welcome to <span className="font-medium text-vy-charcoal/70">Lumyn Pro</span> — unlimited conversations, full memory, and all four modes are now active.
               </p>
-            </div>
+              <div className="p-6 rounded-2xl border border-vy-charcoal/[0.08] bg-white/50 backdrop-blur-sm mb-8 text-left">
+                <h3 className="font-display text-lg font-semibold text-vy-charcoal mb-4">What's Next</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">Unlimited Lumyn conversations with full memory</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">All four modes: reflect, illuminate, anchor, silent</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">Reading history integrated into every conversation</span>
+                  </li>
+                </ul>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <button
+                  onClick={() => navigate("/vybe")}
+                  className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal text-vy-parchment hover:bg-vy-charcoal/90 transition-all duration-200 cursor-pointer border-none"
+                >
+                  Open Lumyn
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              {tierLabel ? (
+                <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
+                  Your <span className="font-medium text-vy-charcoal/70">{tierLabel}</span> credit is ready. Head to Lyf Path to generate your reading.
+                </p>
+              ) : (
+                <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
+                  Your credits have been added to your account.
+                </p>
+              )}
+
+              {/* Credits Display */}
+              <div className="p-6 rounded-2xl border border-vy-gold/20 bg-white/50 backdrop-blur-sm mb-8">
+                <div className="flex items-center justify-center gap-2 mb-2">
+                  <Sparkles className="w-5 h-5 text-vy-gold" />
+                  <span className="font-sans text-xs font-semibold uppercase tracking-[0.12em] text-vy-charcoal/50">
+                    Your Balance
+                  </span>
+                </div>
+                <p className="font-display text-4xl font-bold text-vy-charcoal mb-1">
+                  {creditsLoading ? "..." : credits}
+                </p>
+                <p className="font-sans text-sm text-vy-charcoal/40">
+                  credit{credits !== 1 ? "s" : ""} available
+                </p>
+              </div>
+
+              {/* What's Next */}
+              <div className="p-6 rounded-2xl border border-vy-charcoal/[0.08] bg-white/50 backdrop-blur-sm mb-8 text-left">
+                <h3 className="font-display text-lg font-semibold text-vy-charcoal mb-4">
+                  What's Next
+                </h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">
+                      {tierLabel
+                        ? `Your ${tierLabel} credit is ready to use`
+                        : "Your credits are ready to use across all reading types"}
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">
+                      A confirmation email has been sent to your address
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">
+                      Your credits never expire — use them whenever you're ready
+                    </span>
+                  </li>
+                </ul>
+              </div>
+
+              {/* Transaction ID */}
+              {sessionId && (
+                <div className="p-4 rounded-xl bg-vy-charcoal/[0.03] mb-8">
+                  <p className="font-sans text-xs text-vy-charcoal/40">
+                    Transaction ID:{" "}
+                    <span className="font-mono text-[11px] text-vy-charcoal/30">
+                      {sessionId}
+                    </span>
+                  </p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex flex-col sm:flex-row gap-3">
+                <button
+                  onClick={() => navigate("/lyf-path")}
+                  className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal text-vy-parchment hover:bg-vy-charcoal/90 transition-all duration-200 cursor-pointer border-none"
+                >
+                  {tierLabel ? `Get Your ${tierLabel.split(" ")[0]} Reading` : "Get Your Reading"}
+                </button>
+                <button
+                  onClick={() => navigate("/history")}
+                  className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal/[0.06] text-vy-charcoal hover:bg-vy-charcoal/[0.12] transition-all duration-200 cursor-pointer border-none"
+                >
+                  View History
+                </button>
+              </div>
+
+              <button
+                onClick={() => navigate("/vybe")}
+                className="mt-4 font-sans text-sm text-vy-charcoal/40 hover:text-vy-charcoal/60 transition-colors duration-200 bg-transparent border-none cursor-pointer"
+              >
+                Return to Home
+              </button>
+            </>
           )}
-
-          {/* Actions */}
-          <div className="flex flex-col sm:flex-row gap-3">
-            <button
-              onClick={() => navigate("/lyf-path")}
-              className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal text-vy-parchment hover:bg-vy-charcoal/90 transition-all duration-200 cursor-pointer border-none"
-            >
-              {tierLabel ? `Get Your ${tierLabel.split(" ")[0]} Reading` : "Get Your Reading"}
-            </button>
-            <button
-              onClick={() => navigate("/history")}
-              className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal/[0.06] text-vy-charcoal hover:bg-vy-charcoal/[0.12] transition-all duration-200 cursor-pointer border-none"
-            >
-              View History
-            </button>
-          </div>
-
-          <button
-            onClick={() => navigate("/vybe")}
-            className="mt-4 font-sans text-sm text-vy-charcoal/40 hover:text-vy-charcoal/60 transition-colors duration-200 bg-transparent border-none cursor-pointer"
-          >
-            Return to Home
-          </button>
         </div>
       </main>
 

--- a/apps/web/src/services/iap.ts
+++ b/apps/web/src/services/iap.ts
@@ -60,4 +60,34 @@ export const TIER_TO_PRODUCT_ID: Record<string, string> = {
   'lyf-path': 'com.vyberology.lyf_path',
   'full-vybe': 'com.vyberology.full_vybe',
   deep: 'com.vyberology.deep_attunement',
+  'lumyn-pro': 'com.vyberology.lumyn_pro',  // subscription product
 };
+
+/**
+ * Purchase a subscription product via RevenueCat offering.
+ * Returns true if purchase succeeded, false if cancelled.
+ * NOTE: Lumyn Pro subscription UI is web-first — this function exists
+ * for future native enablement only.
+ */
+export async function purchaseSubscription(productId: string): Promise<boolean> {
+  if (!isNative()) return false
+
+  const { Purchases } = await import('@revenuecat/purchases-capacitor')
+
+  try {
+    const { offerings } = await Purchases.getOfferings()
+    const currentOffering = offerings.current
+    if (!currentOffering) throw new Error('No current offering available')
+
+    const pkg = currentOffering.availablePackages.find(
+      p => p.product.identifier === productId
+    )
+    if (!pkg) throw new Error(`Package ${productId} not found in offering`)
+
+    await Purchases.purchasePackage({ aPackage: pkg })
+    return true
+  } catch (error: any) {
+    if (error.userCancelled) return false
+    throw error
+  }
+}

--- a/apps/web/src/types/lumyn.ts
+++ b/apps/web/src/types/lumyn.ts
@@ -19,6 +19,16 @@ export type LumynDomain =
   | 'existential'
   | 'general'
 
+export type LumynConversation = {
+  id: string
+  user_id: string
+  title?: string
+  mode: 'reflect' | 'illuminate' | 'anchor' | 'silent'
+  status: string
+  created_at: string
+  ended_at?: string
+}
+
 export type ChatResponse = {
   conversationId: string
   message: {
@@ -37,4 +47,5 @@ export type ChatResponse = {
     crisis_banner: boolean
     anchor_active: boolean
   }
+  paywall?: true
 }

--- a/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
+++ b/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
@@ -629,32 +629,16 @@ Insert this block before the rate limit check at line 121:
     }
   }
 
-  // ── Coerce mode for free users ─────────────────────────────
-  // IMPORTANT: The orchestrator already declares `let effectiveMode` at line 279
-  // for the crisis anchor override. We must also update the `mode` binding at line 118
-  // (see note below) rather than introducing a second variable.
+  // ── Coerce mode for free users (declared here, AFTER isPro is available) ──
+  const mode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
 ```
 
-**Also edit line 118** — replace:
-```ts
-const mode: LumynMode = params.mode ?? 'reflect'
-```
-with:
-```ts
-// For free users, coerce to reflect mode regardless of what was requested
-const mode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
-```
+**Also delete the original `mode` declaration at line 118** (which currently reads `const mode: LumynMode = params.mode ?? 'reflect'`). The new declaration above replaces it — placing `mode` after `isPro` is declared so the coercion compiles correctly.
 
 This ensures the coerced mode flows through all downstream uses of `mode` in the function:
 - `getOrCreateConversation(supabase, userId, params.conversationId, mode)` — conversation stored with correct mode
 - `buildFallbackResponse(RATE_LIMIT_MESSAGE, mode, conversationId)` — fallback uses correct mode
 - `let effectiveMode = mode` at line 279 — crisis anchor override starts from the coerced mode
-
-After making this edit, remove the `requestedMode` variable from Step 3 — the `mode` binding itself now carries the coercion:
-
-```ts
-  // (no separate requestedMode needed — mode is already coerced above)
-```
 
 - [ ] **Step 4: Strip context for free users**
 

--- a/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
+++ b/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
@@ -371,6 +371,7 @@ const SUBSCRIPTION_PRODUCTS = new Set(['com.vyberology.lumyn_pro'])
 
 2. Add the subscription handling blocks **inside `serve()`** as **top-level sibling `if` blocks** — i.e., at the same nesting level as the existing `if (eventType === 'INITIAL_PURCHASE' || ...)` block, NOT inside it. Place them after that existing block, before the `CANCELLATION` refund block:
 
+```ts
 // Handle Lumyn Pro subscription grants
 if (
   (eventType === 'INITIAL_PURCHASE' || eventType === 'RENEWAL' || eventType === 'REACTIVATION') &&
@@ -630,9 +631,29 @@ Insert this block before the rate limit check at line 121:
 
   // ── Coerce mode for free users ─────────────────────────────
   // IMPORTANT: The orchestrator already declares `let effectiveMode` at line 279
-  // for the crisis anchor override. Use a different name here to avoid a duplicate
-  // binding compile error. Pass `requestedMode` through to prompt assembly.
-  const requestedMode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
+  // for the crisis anchor override. We must also update the `mode` binding at line 118
+  // (see note below) rather than introducing a second variable.
+```
+
+**Also edit line 118** — replace:
+```ts
+const mode: LumynMode = params.mode ?? 'reflect'
+```
+with:
+```ts
+// For free users, coerce to reflect mode regardless of what was requested
+const mode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
+```
+
+This ensures the coerced mode flows through all downstream uses of `mode` in the function:
+- `getOrCreateConversation(supabase, userId, params.conversationId, mode)` — conversation stored with correct mode
+- `buildFallbackResponse(RATE_LIMIT_MESSAGE, mode, conversationId)` — fallback uses correct mode
+- `let effectiveMode = mode` at line 279 — crisis anchor override starts from the coerced mode
+
+After making this edit, remove the `requestedMode` variable from Step 3 — the `mode` binding itself now carries the coercion:
+
+```ts
+  // (no separate requestedMode needed — mode is already coerced above)
 ```
 
 - [ ] **Step 4: Strip context for free users**

--- a/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
+++ b/docs/superpowers/plans/2026-03-19-lumyn-pro-subscription.md
@@ -1,0 +1,1362 @@
+# Lumyn Pro Subscription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a $14.97/month Lumyn Pro subscription that gates memory persistence, all four modes, reading history context, and full thread history behind a paywall, with a 10-message free tier and thread switcher UI.
+
+**Architecture:** Entitlement lives on `user_profiles` (`lumyn_pro`, `lumyn_pro_until`, `lumyn_messages_used`). Stripe webhook maintains it server-side. The orchestrator enforces it atomically using a DB RPC before any LLM call. Client reads entitlement once on mount via `useLumynEntitlement` hook; server is the real enforcement point.
+
+**Tech Stack:** Supabase (Postgres migrations, Edge Functions / Deno), Stripe (subscription checkout + webhook), RevenueCat (native IAP — web-first release, native hidden until tested), React + TypeScript (hooks, components), shadcn/ui, Tailwind CSS.
+
+---
+
+## File Map
+
+**New files:**
+- `supabase/migrations/20260319000000_lumyn_pro.sql` — user_profiles columns, `lumyn_increment_free_messages` RPC, product/price seed
+- `apps/web/src/hooks/useLumynEntitlement.ts` — client entitlement hook
+- `apps/web/src/components/LumynPaywallCard.tsx` — inline upsell component
+- `apps/web/src/components/LumynThreadList.tsx` — thread drawer component
+
+**Modified files:**
+- `supabase/functions/stripe-webhook/index.ts` — add `isLumynProPrice`, `setLumynPro`, customer lookup in `handleSubscriptionDeleted`, entitlement update in `handleSubscriptionUpdate`
+- `supabase/functions/create-checkout-session/index.ts` — subscription mode branch
+- `supabase/functions/validate-iap-receipt/index.ts` — handle `INITIAL_PURCHASE` / `RENEWAL` for `lumyn_pro` product
+- `supabase/functions/lumyn-chat/db.ts` — add `getUserEntitlement`, `resolveLumynEntitlement`
+- `supabase/functions/lumyn-chat/types.ts` — add `paywall?: true` to `ChatResponse`, add `LumynSafetyEvent` union member
+- `apps/web/src/types/lumyn.ts` — add `paywall?: true` to `ChatResponse`, add `LumynConversation` export
+- `supabase/functions/lumyn-chat/orchestrator.ts` — entitlement gate, free-tier feature gates, paywall event logging
+- `apps/web/src/services/iap.ts` — add `lumyn-pro` product ID, add `purchaseSubscription`
+- `apps/web/src/components/LumynChatFab.tsx` — wire entitlement hook, thread switcher, paywall card, message counter
+- `apps/web/src/pages/PaymentSuccess.tsx` — lumyn-pro case, immediate entitlement re-fetch, welcome toast
+
+---
+
+## Task 1: DB Migration
+
+**Files:**
+- Create: `supabase/migrations/20260319000000_lumyn_pro.sql`
+
+> Before writing, verify the existing `user_profiles` columns: `SELECT column_name FROM information_schema.columns WHERE table_name = 'user_profiles'` via Supabase dashboard or `supabase db execute`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/20260319000000_lumyn_pro.sql
+
+-- Add Lumyn Pro entitlement columns to user_profiles
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS lumyn_pro            BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS lumyn_pro_until      TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS lumyn_messages_used  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS lumyn_last_message_at TIMESTAMPTZ;
+
+-- Atomic free-message increment
+-- Returns new count, or NULL if limit already hit (0 rows updated)
+CREATE OR REPLACE FUNCTION lumyn_increment_free_messages(p_user_id UUID)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_new_count INTEGER;
+BEGIN
+  UPDATE user_profiles
+    SET lumyn_messages_used = lumyn_messages_used + 1
+    WHERE user_id = p_user_id
+      AND lumyn_messages_used < 10
+      AND lumyn_pro = false
+    RETURNING lumyn_messages_used INTO v_new_count;
+  RETURN v_new_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION lumyn_increment_free_messages(UUID) TO authenticated;
+
+-- Seed Lumyn Pro product + price
+-- Replace placeholder IDs with real Stripe IDs before deploy
+INSERT INTO products (stripe_product_id, name, description, active)
+VALUES ('prod_lumyn_pro', 'Lumyn Pro', 'Unlimited Lumyn conversations with full memory and all modes', true)
+ON CONFLICT (stripe_product_id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description;
+
+INSERT INTO prices (product_id, stripe_price_id, currency, unit_amount, interval, interval_count, active)
+VALUES (
+  (SELECT id FROM products WHERE stripe_product_id = 'prod_lumyn_pro'),
+  'price_lumyn_pro_monthly',
+  'usd',
+  1497,
+  'month',
+  1,
+  true
+)
+ON CONFLICT (stripe_price_id) DO UPDATE SET unit_amount = EXCLUDED.unit_amount, active = EXCLUDED.active;
+```
+
+- [ ] **Step 2: Apply migration**
+
+```bash
+supabase db push
+```
+
+Expected: migration applies cleanly, no errors.
+
+- [ ] **Step 3: Verify**
+
+Run via Supabase SQL editor or CLI:
+```sql
+SELECT lumyn_pro, lumyn_pro_until, lumyn_messages_used, lumyn_last_message_at
+FROM user_profiles LIMIT 1;
+```
+Expected: columns exist, all values are defaults (`false`, `null`, `0`, `null`).
+
+```sql
+SELECT lumyn_increment_free_messages('<any-real-user-uuid>');
+```
+Expected: returns `1` (first increment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260319000000_lumyn_pro.sql
+git commit -m "feat(lumyn-pro): add user_profiles entitlement columns and free-message RPC"
+```
+
+---
+
+## Task 2: Stripe Webhook — entitlement helpers
+
+**Files:**
+- Modify: `supabase/functions/stripe-webhook/index.ts`
+
+This task adds `isLumynProPrice`, `setLumynPro`, and wires both into `handleSubscriptionUpdate` and `handleSubscriptionDeleted`.
+
+- [ ] **Step 1: Add `isLumynProPrice` helper**
+
+Add after the existing `calculateCreditsFromAmount` function at the bottom of the file:
+
+```ts
+/**
+ * Returns true if any subscription line item matches the Lumyn Pro price.
+ * Checks all items (not just [0]) for robustness.
+ */
+function isLumynProPrice(subscription: Stripe.Subscription): boolean {
+  const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
+  if (!lumynProPriceId) return false
+  return subscription.items.data.some(item => item.price.id === lumynProPriceId)
+}
+
+/**
+ * Set or clear Lumyn Pro entitlement on user_profiles.
+ * Uses upsert so it is safe if the profile row doesn't exist yet.
+ * Only touches lumyn_pro and lumyn_pro_until — other columns are unaffected.
+ */
+async function setLumynPro(
+  supabase: any,
+  userId: string,
+  isPro: boolean,
+  proUntil: string | null
+): Promise<void> {
+  const { error } = await supabase.from('user_profiles').upsert({
+    user_id: userId,
+    lumyn_pro: isPro,
+    lumyn_pro_until: proUntil,
+  }, { onConflict: 'user_id' })
+  if (error) console.error('setLumynPro failed:', error.message)
+}
+```
+
+- [ ] **Step 2: Update `handleSubscriptionUpdate`**
+
+At the end of `handleSubscriptionUpdate`, after the existing `await supabase.from('subscriptions').upsert(...)` call, add:
+
+```ts
+  // Grant/confirm Lumyn Pro if this is the Pro subscription
+  if (isLumynProPrice(subscription) && subscription.status === 'active') {
+    await setLumynPro(supabase, userId, true, null)
+  }
+```
+
+- [ ] **Step 3: Update `handleSubscriptionDeleted`**
+
+Replace the existing `handleSubscriptionDeleted` function body with:
+
+```ts
+async function handleSubscriptionDeleted(
+  subscription: Stripe.Subscription,
+  supabase: any
+) {
+  // Update subscription status in database (existing logic)
+  await supabase
+    .from('subscriptions')
+    .update({
+      status: 'canceled',
+      ended_at: new Date().toISOString(),
+    })
+    .eq('stripe_subscription_id', subscription.id)
+
+  console.log(`Deleted subscription ${subscription.id}`)
+
+  // Resolve userId via customer lookup (mirrors handleSubscriptionUpdate)
+  const customer = await stripe.customers.retrieve(subscription.customer as string)
+  const userId = (customer as Stripe.Customer).metadata?.supabase_user_id
+  if (!userId) {
+    console.error('No supabase_user_id in customer metadata on deletion')
+    return
+  }
+
+  // Revoke Lumyn Pro if this is the Pro subscription
+  if (isLumynProPrice(subscription)) {
+    const proUntil = new Date(subscription.current_period_end * 1000).toISOString()
+    await setLumynPro(supabase, userId, false, proUntil)
+    console.log(`Revoked Lumyn Pro for user ${userId}, until ${proUntil}`)
+  }
+}
+```
+
+- [ ] **Step 4: Set the secret**
+
+```bash
+supabase secrets set LUMYN_PRO_STRIPE_PRICE_ID=price_REAL_ID_HERE
+```
+
+(Use the real Stripe price ID once created in the Stripe dashboard.)
+
+- [ ] **Step 5: Deploy**
+
+```bash
+supabase functions deploy stripe-webhook
+```
+
+- [ ] **Step 6: Smoke test**
+
+In Stripe dashboard → Developers → Webhooks → send a test `customer.subscription.updated` event. Check Supabase logs for `stripe-webhook`:
+```bash
+supabase functions logs stripe-webhook --tail
+```
+Expected: no errors, "Updated subscription..." logged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/functions/stripe-webhook/index.ts
+git commit -m "feat(lumyn-pro): add setLumynPro and Lumyn Pro price guard to stripe webhook"
+```
+
+---
+
+## Task 3: Checkout — subscription mode branch
+
+**Files:**
+- Modify: `supabase/functions/create-checkout-session/index.ts`
+
+- [ ] **Step 1: Replace the session creation block**
+
+Find the `const session = await stripe.checkout.sessions.create({...})` block (lines 98–122 in the current file). Replace it with:
+
+```ts
+    const isSubscription = tier === 'lumyn-pro'
+
+    const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      line_items: [
+        {
+          price: priceId,
+          quantity,
+        },
+      ],
+      mode: isSubscription ? 'subscription' : 'payment',
+      success_url: successUrl || `${req.headers.get('origin')}/payment/success?session_id={CHECKOUT_SESSION_ID}${isSubscription ? '&upgraded=true&tier=lumyn-pro' : ''}`,
+      cancel_url: cancelUrl || `${req.headers.get('origin')}/payment/cancel`,
+      metadata: {
+        user_id: user.id,
+        ...(tier && { tier }),
+        ...(fullName && { full_name: fullName }),
+        ...(dob && { dob }),
+      },
+      billing_address_collection: 'auto',
+      ...(isSubscription
+        ? { subscription_data: { metadata: { user_id: user.id, tier } } }
+        : {
+            payment_intent_data: {
+              metadata: {
+                user_id: user.id,
+                ...(tier && { tier }),
+              },
+            },
+          }),
+    })
+```
+
+- [ ] **Step 2: Deploy**
+
+```bash
+supabase functions deploy create-checkout-session
+```
+
+- [ ] **Step 3: Smoke test (local)**
+
+Trigger a subscription checkout from the browser dev console (or use Stripe's test mode). Check that:
+- The Stripe checkout page shows recurring billing ($14.97/month), not one-time
+- Success URL includes `upgraded=true&tier=lumyn-pro`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/functions/create-checkout-session/index.ts
+git commit -m "feat(lumyn-pro): add subscription mode branch to create-checkout-session"
+```
+
+---
+
+## Task 4: IAP — native subscription path
+
+**Files:**
+- Modify: `apps/web/src/services/iap.ts`
+- Modify: `supabase/functions/validate-iap-receipt/index.ts`
+
+> **Note:** The native Lumyn Pro purchase UI is hidden until device-tested. These changes wire the backend path — the UI (in `LumynPaywallCard`) will keep the native path disabled via `isNative()` guard.
+
+- [ ] **Step 1: Add product ID and `purchaseSubscription` to `iap.ts`**
+
+In `apps/web/src/services/iap.ts`, update `TIER_TO_PRODUCT_ID`:
+
+```ts
+export const TIER_TO_PRODUCT_ID: Record<string, string> = {
+  'lyf-path': 'com.vyberology.lyf_path',
+  'full-vybe': 'com.vyberology.full_vybe',
+  deep: 'com.vyberology.deep_attunement',
+  'lumyn-pro': 'com.vyberology.lumyn_pro',  // subscription product
+}
+```
+
+Add after `purchaseProduct`:
+
+```ts
+/**
+ * Purchase a subscription product via RevenueCat offering.
+ * Returns true if purchase succeeded, false if cancelled.
+ * NOTE: Lumyn Pro subscription UI is web-first — this function exists
+ * for future native enablement only.
+ */
+export async function purchaseSubscription(productId: string): Promise<boolean> {
+  if (!isNative()) return false
+
+  const { Purchases } = await import('@revenuecat/purchases-capacitor')
+
+  try {
+    const { offerings } = await Purchases.getOfferings()
+    const currentOffering = offerings.current
+    if (!currentOffering) throw new Error('No current offering available')
+
+    const pkg = currentOffering.availablePackages.find(
+      p => p.product.identifier === productId
+    )
+    if (!pkg) throw new Error(`Package ${productId} not found in offering`)
+
+    await Purchases.purchasePackage({ aPackage: pkg })
+    return true
+  } catch (error: any) {
+    if (error.userCancelled) return false
+    throw error
+  }
+}
+```
+
+- [ ] **Step 2: Update `validate-iap-receipt` to handle Lumyn Pro subscription events**
+
+In `supabase/functions/validate-iap-receipt/index.ts`:
+
+1. Add the constant **at module level** (outside `serve()`), after the `PRODUCT_CREDITS` map:
+
+```ts
+// Subscription product IDs that grant Lumyn Pro
+const SUBSCRIPTION_PRODUCTS = new Set(['com.vyberology.lumyn_pro'])
+```
+
+2. Add the subscription handling blocks **inside `serve()`** as **top-level sibling `if` blocks** — i.e., at the same nesting level as the existing `if (eventType === 'INITIAL_PURCHASE' || ...)` block, NOT inside it. Place them after that existing block, before the `CANCELLATION` refund block:
+
+// Handle Lumyn Pro subscription grants
+if (
+  (eventType === 'INITIAL_PURCHASE' || eventType === 'RENEWAL' || eventType === 'REACTIVATION') &&
+  SUBSCRIPTION_PRODUCTS.has(event.product_id) &&
+  appUserId
+) {
+  const { error } = await supabase.from('user_profiles').upsert({
+    user_id: appUserId,
+    lumyn_pro: true,
+    lumyn_pro_until: null,
+  }, { onConflict: 'user_id' })
+  if (error) console.error('Failed to grant Lumyn Pro (IAP):', error.message)
+  else console.log(`Granted Lumyn Pro to user ${appUserId} via ${eventType}`)
+}
+
+// Handle Lumyn Pro subscription cancellations
+if (
+  eventType === 'EXPIRATION' &&
+  SUBSCRIPTION_PRODUCTS.has(event.product_id) &&
+  appUserId
+) {
+  const { error } = await supabase.from('user_profiles').upsert({
+    user_id: appUserId,
+    lumyn_pro: false,
+    lumyn_pro_until: event.expiration_at_ms
+      ? new Date(event.expiration_at_ms).toISOString()
+      : new Date().toISOString(),
+  }, { onConflict: 'user_id' })
+  if (error) console.error('Failed to revoke Lumyn Pro (IAP):', error.message)
+}
+```
+
+- [ ] **Step 3: Deploy**
+
+```bash
+supabase functions deploy validate-iap-receipt
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/services/iap.ts supabase/functions/validate-iap-receipt/index.ts
+git commit -m "feat(lumyn-pro): add native subscription IAP path (web-first, native hidden)"
+```
+
+---
+
+## Task 5: Types — add `paywall` field
+
+**Files:**
+- Modify: `supabase/functions/lumyn-chat/types.ts`
+- Modify: `apps/web/src/types/lumyn.ts`
+
+- [ ] **Step 1: Update edge function types**
+
+In `supabase/functions/lumyn-chat/types.ts`, update the `LumynSafetyEvent` type and `ChatResponse`:
+
+```ts
+// Line 60 — extend LumynSafetyEvent union
+export type LumynSafetyEvent = 'crisis_detected' | 'overreach_blocked' | 'escalation' | 'paywall_hit'
+
+// Line 248 — add paywall field to ChatResponse
+export type ChatResponse = {
+  conversationId: string
+  message: {
+    id: string
+    role: 'assistant'
+    content: string
+    created_at: string
+  }
+  mode: LumynMode
+  classification: {
+    intent: LumynIntent
+    emotion: string
+    domain: LumynDomain
+  }
+  client_directives: {
+    crisis_banner: boolean
+    anchor_active: boolean
+  }
+  paywall?: true
+}
+```
+
+- [ ] **Step 2: Update client types**
+
+In `apps/web/src/types/lumyn.ts`, add `paywall` to `ChatResponse` and export `LumynConversation` (needed by thread list):
+
+```ts
+export type LumynConversation = {
+  id: string
+  user_id: string
+  title?: string
+  mode: 'reflect' | 'illuminate' | 'anchor' | 'silent'
+  status: string
+  created_at: string
+  ended_at?: string
+}
+
+export type ChatResponse = {
+  conversationId: string
+  message: {
+    id: string
+    role: 'assistant'
+    content: string
+    created_at: string
+  }
+  mode: LumynMode
+  classification: {
+    intent: LumynIntent
+    emotion: string
+    domain: LumynDomain
+  }
+  client_directives: {
+    crisis_banner: boolean
+    anchor_active: boolean
+  }
+  paywall?: true
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/functions/lumyn-chat/types.ts apps/web/src/types/lumyn.ts
+git commit -m "feat(lumyn-pro): add paywall field to ChatResponse types"
+```
+
+---
+
+## Task 6: Orchestrator — entitlement gate + free-tier gates
+
+**Files:**
+- Modify: `supabase/functions/lumyn-chat/db.ts`
+- Modify: `supabase/functions/lumyn-chat/orchestrator.ts`
+
+### 6a: DB helpers
+
+- [ ] **Step 1: Add `getUserEntitlement` and `resolveLumynEntitlement` to `db.ts`**
+
+Add after the `createSupabaseClient` function:
+
+```ts
+// ─────────────────────────────────────────────
+// Lumyn Pro entitlement
+// ─────────────────────────────────────────────
+
+export type LumynEntitlement = {
+  lumyn_pro: boolean
+  lumyn_pro_until: string | null
+  lumyn_messages_used: number
+}
+
+export async function getUserEntitlement(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<LumynEntitlement> {
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('lumyn_pro, lumyn_pro_until, lumyn_messages_used')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error || !data) {
+    // No profile row → treat as free tier, 0 messages used
+    return { lumyn_pro: false, lumyn_pro_until: null, lumyn_messages_used: 0 }
+  }
+
+  return {
+    lumyn_pro: data.lumyn_pro ?? false,
+    lumyn_pro_until: data.lumyn_pro_until ?? null,
+    lumyn_messages_used: data.lumyn_messages_used ?? 0,
+  }
+}
+
+/**
+ * Single entitlement resolver — use everywhere, never duplicate this logic.
+ */
+export function resolveLumynEntitlement(entitlement: LumynEntitlement): boolean {
+  return (
+    entitlement.lumyn_pro &&
+    (entitlement.lumyn_pro_until === null ||
+      new Date(entitlement.lumyn_pro_until) > new Date())
+  )
+}
+```
+
+### 6b: Orchestrator changes
+
+- [ ] **Step 2: Add imports to `orchestrator.ts`**
+
+At the top of `orchestrator.ts`, find the existing `import { ... } from './db.ts'` block and add `getUserEntitlement` and `resolveLumynEntitlement` to it. The full updated import must enumerate all existing named exports — do not use a truncated `// ... existing imports ...` placeholder. The complete import after editing:
+
+```ts
+import {
+  getOrCreateConversation,
+  getOrCreateUserModel,
+  getSessionHistory,
+  getClaims,
+  getRecentPatterns,
+  getGuidingPrinciples,
+  getMemorableMoments,
+  insertMessage,
+  logSafetyEvent,
+  logMemoryOps,
+  upsertRateLimit,
+  closeStaleConversations,
+  upsertClaim,
+  deprecateClaim,
+  getUserEntitlement,
+  resolveLumynEntitlement,
+} from './db.ts'
+```
+
+- [ ] **Step 3: Add entitlement gate before Step 1 (rate limit) in `runOrchestrator`**
+
+Insert this block before the rate limit check at line 121:
+
+```ts
+  // ── Entitlement check ─────────────────────────────────────
+  const entitlement = await getUserEntitlement(supabase, userId)
+  const isPro = resolveLumynEntitlement(entitlement)
+
+  if (!isPro) {
+    // Atomic free-message increment — returns null if limit hit
+    const { data: newCount } = await supabase.rpc('lumyn_increment_free_messages', {
+      p_user_id: userId,
+    })
+
+    if (newCount === null) {
+      // Paywall hit — log event and return paywall response
+      await logSafetyEvent(supabase, {
+        user_id: userId,
+        event_type: 'paywall_hit',
+        trigger_source: 'policy',
+        details: {
+          messages_used: entitlement.lumyn_messages_used,
+          mode_requested: params.mode ?? 'reflect',
+        },
+      })
+
+      return {
+        conversationId: params.conversationId ?? 'no-conversation',
+        message: {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          content: '',
+          created_at: new Date().toISOString(),
+        },
+        mode: 'reflect',
+        classification: { intent: 'explore', emotion: 'neutral', domain: 'general' },
+        client_directives: { crisis_banner: false, anchor_active: false },
+        paywall: true,
+      }
+    }
+  }
+
+  // ── Coerce mode for free users ─────────────────────────────
+  // IMPORTANT: The orchestrator already declares `let effectiveMode` at line 279
+  // for the crisis anchor override. Use a different name here to avoid a duplicate
+  // binding compile error. Pass `requestedMode` through to prompt assembly.
+  const requestedMode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
+```
+
+- [ ] **Step 4: Strip context for free users**
+
+The orchestrator currently destructures `vyberologyContext` from `params` at line 117:
+```ts
+const { supabase, userId, message, vyberologyContext } = params
+```
+
+**Edit line 117** to remove `vyberologyContext` from the destructure (to avoid a duplicate `const` binding error):
+```ts
+const { supabase, userId, message } = params
+```
+
+Then, after the entitlement gate block, declare the filtered version:
+
+```ts
+  // Strip reading history and user profile for free users
+  const vyberologyContext = isPro
+    ? params.vyberologyContext
+    : params.vyberologyContext.filter(
+        (i) => i.label !== 'ReadingHistory' && i.label !== 'UserProfile'
+      )
+```
+
+This single `const vyberologyContext` is then used everywhere in the function body where `params.vyberologyContext` was previously referenced.
+
+- [ ] **Step 5: Skip memory writes for free users**
+
+In Step 8 (memory write), wrap the `processMemorableMoments` call and the memory suggestions loop:
+
+```ts
+  // Memory writes — Pro only
+  if (isPro) {
+    await processMemorableMoments(
+      userId,
+      conversationId,
+      llmData.memorable_moments,
+      [...sessionHistory, userMsg, assistantMsg],
+      supabase
+    )
+
+    // ... existing memory suggestions loop ...
+    if (memoryOps.length > 0) {
+      await logMemoryOps(supabase, memoryOps)
+    }
+  }
+```
+
+Also skip `generateConversationSummary` for free users (already inside a `conversation.status === 'closed'` check — add `&& isPro` condition).
+
+- [ ] **Step 6: Deploy**
+
+```bash
+supabase functions deploy lumyn-chat
+```
+
+- [ ] **Step 7: Smoke test**
+
+Use curl or the live app as a free user. Send 11 messages. On the 11th:
+```bash
+curl -X POST <SUPABASE_URL>/functions/v1/lumyn-chat \
+  -H "Authorization: Bearer <USER_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"test","vyberologyContext":[]}'
+```
+Expected response includes `"paywall": true`.
+
+Also verify `lumyn_safety_events` has a row with `event_type = 'paywall_hit'`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add supabase/functions/lumyn-chat/db.ts supabase/functions/lumyn-chat/orchestrator.ts
+git commit -m "feat(lumyn-pro): add entitlement gate and free-tier feature gates to orchestrator"
+```
+
+---
+
+## Task 7: `useLumynEntitlement` hook
+
+**Files:**
+- Create: `apps/web/src/hooks/useLumynEntitlement.ts`
+
+- [ ] **Step 1: Write the hook**
+
+```ts
+// apps/web/src/hooks/useLumynEntitlement.ts
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/integrations/supabase/client'
+
+export type LumynEntitlement = {
+  isPro: boolean
+  messagesUsed: number
+  isLoading: boolean
+  refetch: () => Promise<void>
+}
+
+export function useLumynEntitlement(): LumynEntitlement {
+  const [isPro, setIsPro] = useState(false)
+  const [messagesUsed, setMessagesUsed] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetch = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        setIsPro(false)
+        setMessagesUsed(0)
+        return
+      }
+
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('lumyn_pro, lumyn_pro_until, lumyn_messages_used')
+        .eq('user_id', user.id)
+        .maybeSingle()
+
+      if (error || !data) {
+        setIsPro(false)
+        setMessagesUsed(0)
+        return
+      }
+
+      const resolvedPro =
+        data.lumyn_pro &&
+        (data.lumyn_pro_until === null || new Date(data.lumyn_pro_until) > new Date())
+
+      setIsPro(resolvedPro)
+      setMessagesUsed(data.lumyn_messages_used ?? 0)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
+
+  return { isPro, messagesUsed, isLoading, refetch: fetch }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/hooks/useLumynEntitlement.ts
+git commit -m "feat(lumyn-pro): add useLumynEntitlement hook"
+```
+
+---
+
+## Task 8: Thread list component
+
+**Files:**
+- Create: `apps/web/src/components/LumynThreadList.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// apps/web/src/components/LumynThreadList.tsx
+import { useEffect, useState, useCallback } from 'react'
+import { Plus, MessageSquare, Crown } from 'lucide-react'
+import { supabase } from '@/integrations/supabase/client'
+import type { LumynConversation } from '@/types/lumyn'
+
+interface Props {
+  currentConversationId: string | undefined
+  isPro: boolean
+  onSelectThread: (conversation: LumynConversation) => void
+  onNewThread: () => void
+  onUpgrade: () => void
+}
+
+export function LumynThreadList({
+  currentConversationId,
+  isPro,
+  onSelectThread,
+  onNewThread,
+  onUpgrade,
+}: Props) {
+  const [threads, setThreads] = useState<LumynConversation[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const loadThreads = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+
+      const query = supabase
+        .from('lumyn_conversations')
+        .select('id, title, mode, status, created_at, ended_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false })
+
+      if (!isPro) {
+        query.limit(1)
+      } else {
+        query.limit(10)
+      }
+
+      const { data, error } = await query
+      if (!error && data) setThreads(data as LumynConversation[])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isPro])
+
+  useEffect(() => { loadThreads() }, [loadThreads])
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* New conversation button */}
+      <button
+        onClick={onNewThread}
+        className="flex items-center gap-2 w-full px-4 py-3 text-sm font-medium text-vy-charcoal hover:bg-vy-charcoal/5 transition-colors border-b border-vy-charcoal/10"
+      >
+        <Plus className="w-4 h-4" />
+        New conversation
+      </button>
+
+      {/* Thread list */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="p-4 text-center text-xs text-vy-charcoal/40">Loading…</div>
+        ) : threads.length === 0 ? (
+          <div className="p-4 text-center text-xs text-vy-charcoal/40">No conversations yet.</div>
+        ) : (
+          threads.map((thread) => {
+            const title = thread.title || `Conversation · ${formatDate(thread.created_at)}`
+            const isActive = thread.id === currentConversationId
+            return (
+              <button
+                key={thread.id}
+                onClick={() => onSelectThread(thread)}
+                className={`w-full text-left px-4 py-3 border-b border-vy-charcoal/[0.06] transition-colors hover:bg-vy-charcoal/5 ${
+                  isActive ? 'bg-vy-gold/10' : ''
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-0.5">
+                  <MessageSquare className="w-3 h-3 text-vy-charcoal/30 shrink-0" />
+                  <span className="text-sm font-medium text-vy-charcoal truncate">{title}</span>
+                </div>
+                <div className="flex items-center gap-2 pl-5">
+                  <span className="text-[10px] uppercase tracking-wide text-vy-charcoal/30">
+                    {thread.mode}
+                  </span>
+                  <span className="text-[10px] text-vy-charcoal/30">·</span>
+                  <span className="text-[10px] text-vy-charcoal/30">
+                    {formatDate(thread.created_at)}
+                  </span>
+                </div>
+              </button>
+            )
+          })
+        )}
+      </div>
+
+      {/* Pro upgrade banner — free users only */}
+      {!isPro && (
+        <div className="border-t border-vy-charcoal/10 p-4">
+          <p className="text-xs text-vy-charcoal/50 mb-2">
+            Unlock full conversation history with Pro.
+          </p>
+          <button
+            onClick={onUpgrade}
+            className="flex items-center gap-1.5 w-full justify-center py-2 rounded-lg bg-gradient-to-r from-vy-gold to-amber-500 text-white text-xs font-semibold"
+          >
+            <Crown className="w-3 h-3" />
+            Upgrade to Lumyn Pro
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/components/LumynThreadList.tsx
+git commit -m "feat(lumyn-pro): add LumynThreadList drawer component"
+```
+
+---
+
+## Task 9: `LumynPaywallCard` component
+
+**Files:**
+- Create: `apps/web/src/components/LumynPaywallCard.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// apps/web/src/components/LumynPaywallCard.tsx
+import { Crown } from 'lucide-react'
+import { purchaseTier } from '@/services/purchase'
+import { isNative } from '@/lib/platform'
+
+const LUMYN_PRO_PRICE_ID = import.meta.env.VITE_LUMYN_PRO_PRICE_ID ?? ''
+
+interface Props {
+  onUpgradeStart?: () => void
+}
+
+export function LumynPaywallCard({ onUpgradeStart }: Props) {
+  const handleUpgrade = async () => {
+    onUpgradeStart?.()
+
+    if (isNative()) {
+      // Native subscription path is not yet enabled for Lumyn Pro
+      // Show a message directing users to web
+      alert('Please visit vyberology.com to upgrade to Lumyn Pro.')
+      return
+    }
+
+    const result = await purchaseTier('lumyn-pro', {
+      priceId: LUMYN_PRO_PRICE_ID,
+      fullName: '',
+      dob: '',
+    })
+
+    if (result.redirectUrl) {
+      window.location.href = result.redirectUrl
+    }
+  }
+
+  return (
+    <div className="mx-2 my-1 rounded-2xl border border-vy-gold/30 bg-gradient-to-br from-vy-gold/5 to-amber-50/50 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Crown className="w-4 h-4 text-vy-gold shrink-0" />
+        <span className="text-sm font-semibold text-vy-charcoal">
+          You've used your 10 free messages with Lumyn.
+        </span>
+      </div>
+      <p className="text-xs text-vy-charcoal/60 mb-3 pl-6">
+        Upgrade to Pro for unlimited conversations, full memory, and all four modes — $14.97/month.
+      </p>
+      <button
+        onClick={handleUpgrade}
+        className="w-full py-2.5 rounded-xl bg-gradient-to-r from-vy-gold to-amber-500 text-white text-sm font-semibold hover:opacity-90 transition-opacity"
+      >
+        Upgrade to Lumyn Pro
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/components/LumynPaywallCard.tsx
+git commit -m "feat(lumyn-pro): add LumynPaywallCard inline upsell component"
+```
+
+---
+
+## Task 10: `LumynChatFab` — wire everything together
+
+**Files:**
+- Modify: `apps/web/src/components/LumynChatFab.tsx`
+
+This is the largest UI change. Read the current file before editing (it's ~142 lines).
+
+- [ ] **Step 1: Add imports**
+
+Add at the top of `LumynChatFab.tsx`:
+
+```tsx
+import { MessageSquare } from 'lucide-react'
+import { useLumynEntitlement } from '@/hooks/useLumynEntitlement'
+import { LumynThreadList } from '@/components/LumynThreadList'
+import { LumynPaywallCard } from '@/components/LumynPaywallCard'
+import { supabase } from '@/integrations/supabase/client'
+import { isNative } from '@/lib/platform'
+import type { LumynConversation } from '@/types/lumyn'
+```
+
+- [ ] **Step 2: Add state for thread drawer and entitlement**
+
+Inside `LumynChatFab`, add after the existing state declarations:
+
+```tsx
+  const { isPro, messagesUsed, refetch: refetchEntitlement } = useLumynEntitlement()
+  const [showThreadList, setShowThreadList] = useState(false)
+```
+
+- [ ] **Step 3: Add thread-switching handler**
+
+```tsx
+  const handleSelectThread = async (conversation: LumynConversation) => {
+    setShowThreadList(false)
+    setIsProcessing(true)
+    try {
+      const { data: messages } = await supabase
+        .from('lumyn_messages')
+        .select('role, content')
+        .eq('conversation_id', conversation.id)
+        .order('created_at', { ascending: true })
+
+      if (messages) {
+        setChatMessages(messages as ChatMessage[])
+      }
+      setConversationId(conversation.id)
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  const handleNewThread = () => {
+    setShowThreadList(false)
+    setChatMessages([])
+    setConversationId(undefined)
+    setShowCrisisBanner(false)
+  }
+
+  const handleUpgrade = async () => {
+    const { purchaseTier } = await import('@/services/purchase')
+    const priceId = import.meta.env.VITE_LUMYN_PRO_PRICE_ID ?? ''
+    if (isNative()) {
+      alert('Please visit vyberology.com to upgrade to Lumyn Pro.')
+      return
+    }
+    const result = await purchaseTier('lumyn-pro', { priceId, fullName: '', dob: '' })
+    if (result.redirectUrl) window.location.href = result.redirectUrl
+  }
+```
+
+- [ ] **Step 4: Add `paywallHit` boolean state — do NOT use a sentinel string in `chatMessages`**
+
+The `chatMessages` array is persisted to `localStorage`. Injecting a `__paywall__` sentinel string into it would survive page reload and reappear even after the user upgrades. Instead, track the paywall state separately:
+
+Add new state:
+```tsx
+  const [paywallHit, setPaywallHit] = useState(false)
+```
+
+In `handleSend`, after `setConversationId(response.conversationId)`, add:
+
+```tsx
+      if (response.paywall) {
+        setPaywallHit(true)
+        return  // Do not append any message to chatMessages
+      }
+      // Clear paywall state if it was previously set and user is now Pro
+      setPaywallHit(false)
+```
+
+The `LumynPaywallCard` is rendered conditionally based on `paywallHit` — see Step 5.
+
+- [ ] **Step 5: Update the JSX**
+
+Replace the chat panel header close button section with a version that includes the thread switcher:
+
+```tsx
+            {/* Panel header */}
+            <div className="absolute -top-3 right-0 left-0 flex justify-between items-center px-1">
+              {/* Thread list toggle */}
+              <button
+                onClick={() => setShowThreadList((prev) => !prev)}
+                className="w-7 h-7 rounded-full bg-vy-charcoal text-vy-parchment flex items-center justify-center shadow-lg hover:bg-vy-charcoal/80 transition-colors"
+                title="Conversations"
+              >
+                <MessageSquare className="w-3.5 h-3.5" />
+              </button>
+
+              {/* Free message counter */}
+              {!isPro && (
+                <span className="text-[10px] text-vy-charcoal/40 font-sans">
+                  {messagesUsed} / 10 free messages
+                </span>
+              )}
+
+              {/* Close button */}
+              <button
+                onClick={() => setIsOpen(false)}
+                className="w-7 h-7 rounded-full bg-vy-charcoal text-vy-parchment flex items-center justify-center shadow-lg hover:bg-vy-charcoal/80 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+```
+
+In the `LumenChat` render, update the `messages` prop to render paywall cards for `__paywall__` content:
+
+Pass `messages` through a mapper before handing to `LumenChat`, or handle it inside the LumenChat component. The simplest approach: filter paywall messages out of `LumenChat` and render `LumynPaywallCard` after the message list, outside `LumenChat`.
+
+Add below `<LumenChat .../>`:
+
+```tsx
+            {/* Inline paywall card — shown when server returns paywall:true */}
+            {paywallHit && (
+              <LumynPaywallCard />
+            )}
+```
+
+Add below the `LumenChat` block, the thread list overlay:
+
+```tsx
+            {/* Thread list drawer */}
+            {showThreadList && (
+              <div className="absolute inset-0 z-10 bg-vy-parchment rounded-2xl overflow-hidden flex flex-col">
+                <div className="flex items-center justify-between px-4 py-3 border-b border-vy-charcoal/10">
+                  <span className="text-sm font-semibold text-vy-charcoal">Conversations</span>
+                  <button
+                    onClick={() => setShowThreadList(false)}
+                    className="text-vy-charcoal/40 hover:text-vy-charcoal"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                <LumynThreadList
+                  currentConversationId={conversationId}
+                  isPro={isPro}
+                  onSelectThread={handleSelectThread}
+                  onNewThread={handleNewThread}
+                  onUpgrade={handleUpgrade}
+                />
+              </div>
+            )}
+```
+
+- [ ] **Step 6: Build and check types**
+
+```bash
+cd apps/web && npm run build 2>&1 | tail -30
+```
+
+Expected: no TypeScript errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/LumynChatFab.tsx
+git commit -m "feat(lumyn-pro): wire entitlement hook, thread switcher, paywall card into LumynChatFab"
+```
+
+---
+
+## Task 11: PaymentSuccess page — Lumyn Pro flow
+
+**Files:**
+- Modify: `apps/web/src/pages/PaymentSuccess.tsx`
+
+- [ ] **Step 1: Add `useLumynEntitlement` import and immediate re-fetch**
+
+Add import:
+```tsx
+import { useLumynEntitlement } from '@/hooks/useLumynEntitlement'
+```
+
+Inside `PaymentSuccess`, add:
+```tsx
+  const { refetch: refetchEntitlement } = useLumynEntitlement()
+  const upgraded = searchParams.get('upgraded') === 'true'
+
+  useEffect(() => {
+    if (upgraded) {
+      refetchEntitlement()
+    }
+  }, [upgraded, refetchEntitlement])
+```
+
+- [ ] **Step 2: Add `lumyn-pro` tier label and Lumyn-specific UI**
+
+Update `tierLabel`:
+```tsx
+  const tierLabel =
+    tier === 'full-vybe'
+      ? 'Full VYBE Reading'
+      : tier === 'lyf-path'
+        ? 'Lyf Path Reading'
+        : tier === 'lumyn-pro'
+          ? 'Lumyn Pro'
+          : null
+```
+
+For the Lumyn Pro case, show subscription-appropriate copy instead of credits. Add a conditional block in the JSX:
+
+```tsx
+          {tier === 'lumyn-pro' ? (
+            <>
+              <p className="font-sans text-base font-light text-vy-charcoal/50 mb-8">
+                Welcome to <span className="font-medium text-vy-charcoal/70">Lumyn Pro</span> — unlimited conversations, full memory, and all four modes are now active.
+              </p>
+              {/* What's Next — Lumyn Pro */}
+              <div className="p-6 rounded-2xl border border-vy-charcoal/[0.08] bg-white/50 backdrop-blur-sm mb-8 text-left">
+                <h3 className="font-display text-lg font-semibold text-vy-charcoal mb-4">What's Next</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">Unlimited Lumyn conversations with full memory</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">All four modes: reflect, illuminate, anchor, silent</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <Check className="w-4 h-4 text-vy-gold flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm text-vy-charcoal/60">Reading history integrated into every conversation</span>
+                  </li>
+                </ul>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <button
+                  onClick={() => navigate('/vybe')}
+                  className="flex-1 py-3 rounded-xl font-sans text-sm font-medium bg-vy-charcoal text-vy-parchment hover:bg-vy-charcoal/90 transition-all duration-200 cursor-pointer border-none"
+                >
+                  Open Lumyn
+                </button>
+              </div>
+            </>
+          ) : (
+            // ... existing credit-based JSX blocks ...
+          )}
+```
+
+- [ ] **Step 3: Add welcome toast**
+
+Import `useToast`:
+```tsx
+import { useToast } from '@/components/ui/use-toast'
+```
+
+Add inside component:
+```tsx
+  const { toast } = useToast()
+
+  useEffect(() => {
+    if (upgraded && tier === 'lumyn-pro') {
+      // Wait for entitlement re-fetch to settle
+      const timer = setTimeout(() => {
+        toast({
+          title: 'Welcome to Lumyn Pro',
+          description: 'Enjoy unlimited conversations.',
+        })
+      }, 800)
+      return () => clearTimeout(timer)
+    }
+  }, [upgraded, tier, toast])
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cd apps/web && npm run build 2>&1 | tail -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/PaymentSuccess.tsx
+git commit -m "feat(lumyn-pro): add Lumyn Pro upgrade flow to PaymentSuccess page"
+```
+
+---
+
+## Task 12: Deploy and end-to-end verification
+
+- [ ] **Step 1: Deploy all edge functions**
+
+```bash
+supabase functions deploy lumyn-chat stripe-webhook create-checkout-session validate-iap-receipt
+```
+
+- [ ] **Step 2: Set env vars**
+
+In Vercel/hosting dashboard, set:
+```
+VITE_LUMYN_PRO_PRICE_ID=price_REAL_ID_HERE
+```
+
+In Supabase secrets:
+```bash
+supabase secrets set LUMYN_PRO_STRIPE_PRICE_ID=price_REAL_ID_HERE
+```
+
+- [ ] **Step 3: Replace placeholder Stripe IDs in migration**
+
+Create a new migration or run directly:
+```sql
+UPDATE products SET stripe_product_id = 'prod_REAL_ID' WHERE stripe_product_id = 'prod_lumyn_pro';
+UPDATE prices SET stripe_price_id = 'price_REAL_ID' WHERE stripe_price_id = 'price_lumyn_pro_monthly';
+```
+
+- [ ] **Step 4: Manual test — free tier**
+
+1. Log in as a free user
+2. Send 10 messages to Lumyn
+3. On message 11: verify paywall card appears inline
+4. Verify `lumyn_safety_events` has a `paywall_hit` row
+5. Verify `user_profiles.lumyn_messages_used = 10`
+6. Verify free message counter shows "10 / 10 free messages" in header
+
+- [ ] **Step 5: Manual test — thread switcher**
+
+1. Open Lumyn, send a message
+2. Click the conversations icon (top-left of chat panel)
+3. Verify thread list appears with current conversation
+4. Click "New conversation" — verify chat clears
+5. Send a message in new thread — verify new conversationId
+6. Switch back to original thread — verify messages load
+
+- [ ] **Step 6: Manual test — subscription checkout (Stripe test mode)**
+
+1. Click "Upgrade to Lumyn Pro" from paywall card
+2. Verify Stripe checkout shows recurring billing at $14.97/month
+3. Complete with test card `4242 4242 4242 4242`
+4. Verify redirect to `/payment/success?upgraded=true&tier=lumyn-pro`
+5. Verify welcome toast appears
+6. Verify `user_profiles.lumyn_pro = true`
+7. Return to Lumyn chat — verify paywall is gone, memory features work
+
+- [ ] **Step 7: Final commit and push**
+
+```bash
+git push origin feat/lumyn-intelligence-layer
+```
+
+Update the open PR (#26) to include this work, or create a new PR for the Pro subscription branch.

--- a/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
+++ b/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
@@ -24,7 +24,9 @@ ALTER TABLE user_profiles
 
 - `lumyn_pro` — live entitlement gate, set by Stripe webhook
 - `lumyn_pro_until` — NULL for active managed subscriptions; set to `current_period_end` on cancellation (grace period support)
-- `lumyn_messages_used` — monotonic counter, incremented on each free-tier message send, never decremented
+- `lumyn_messages_used` — monotonic counter, incremented atomically on each free-tier message send via a DB function, never decremented
+
+**Existing users:** the migration adds `lumyn_messages_used = 0` for all existing rows. Historical messages in `lumyn_messages` are not counted toward the free limit — everyone starts fresh post-migration.
 
 ### Entitlement rule (server-side)
 
@@ -41,6 +43,28 @@ is_pro = lumyn_pro AND (lumyn_pro_until IS NULL OR lumyn_pro_until > now())
 | Memory persistence | None (claims/moments/summaries skipped) |
 | Reading history in context | Stripped |
 | Thread history | Most recent conversation only |
+
+### Atomic free-message increment (DB function — part of §1 migration)
+
+To prevent race conditions (two concurrent requests both passing the 10-message guard), the increment is handled by a single SQL function:
+
+```sql
+CREATE OR REPLACE FUNCTION lumyn_increment_free_messages(p_user_id UUID)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_new_count INTEGER;
+BEGIN
+  UPDATE user_profiles
+    SET lumyn_messages_used = lumyn_messages_used + 1
+    WHERE user_id = p_user_id
+      AND lumyn_messages_used < 10
+      AND lumyn_pro = false
+    RETURNING lumyn_messages_used INTO v_new_count;
+  RETURN v_new_count; -- NULL if 0 rows updated (limit already hit or now Pro)
+END;
+$$;
+```
+
+The orchestrator calls this function instead of a read-then-update. A NULL return means the paywall is hit.
 
 ---
 
@@ -64,7 +88,7 @@ VALUES (
 );
 ```
 
-> Real Stripe product/price IDs replace the placeholders above before deploy.
+> Real Stripe product/price IDs replace the placeholders above before deploy. The real `stripe_price_id` is also set in Vercel/hosting env as `VITE_LUMYN_PRO_PRICE_ID` (used client-side by `LumynPaywallCard` to call `purchaseTier`).
 
 ---
 
@@ -72,13 +96,36 @@ VALUES (
 
 ### Web (`create-checkout-session`)
 
-When `tier === 'lumyn-pro'`, use `mode: 'subscription'` instead of `mode: 'payment'`. All other logic (customer lookup/create, metadata, success/cancel URLs) is unchanged.
+When `tier === 'lumyn-pro'`, use `mode: 'subscription'` instead of `mode: 'payment'`. **Critically:** `payment_intent_data` is invalid in subscription mode — it must be conditionally omitted. Use `subscription_data` instead for metadata in the subscription case:
 
 ```ts
-mode: tier === 'lumyn-pro' ? 'subscription' : 'payment',
+const isSubscription = tier === 'lumyn-pro'
+
+const sessionParams = {
+  customer: customerId,
+  line_items: [{ price: priceId, quantity }],
+  mode: isSubscription ? 'subscription' : 'payment',
+  success_url: ...,
+  cancel_url: ...,
+  metadata: { user_id, tier, ... },
+  billing_address_collection: 'auto',
+  ...(isSubscription
+    ? { subscription_data: { metadata: { user_id, tier } } }
+    : { payment_intent_data: { metadata: { user_id, tier } } }),
+}
 ```
 
-Success URL receives `?session_id={CHECKOUT_SESSION_ID}`. The existing `/payment/success` page handles this. Add `?upgraded=true` param to trigger a Pro welcome toast when the user lands back in the app.
+Success URL: `/payment/success?session_id={CHECKOUT_SESSION_ID}&upgraded=true&tier=lumyn-pro` — the `upgraded=true` param triggers the Pro welcome toast; `tier=lumyn-pro` is read by the existing tier label switch in `PaymentSuccess.tsx`.
+
+**`/payment/success` page:** add a `lumyn-pro` case to the tier label switch so the page shows subscription-appropriate copy (not "reading credits"). The `tier` param must be included in the success URL (above) — it is not derived from the Stripe session server-side.
+
+### `purchaseTier` signature
+
+`purchaseTier` requires `{ fullName, dob, priceId }`. For `lumyn-pro`, `fullName` and `dob` are irrelevant — pass empty strings. The `create-checkout-session` function only uses them as metadata, and they are not required by Stripe:
+
+```ts
+purchaseTier('lumyn-pro', { priceId: LUMYN_PRO_PRICE_ID, fullName: '', dob: '' })
+```
 
 ### Native IAP (`iap.ts`)
 
@@ -87,7 +134,7 @@ Add to `TIER_TO_PRODUCT_ID`:
 'lumyn-pro': 'com.vyberology.lumyn_pro'
 ```
 
-RevenueCat entitlement check after purchase sets `lumyn_pro = true` via the same `setLumynPro` DB helper called by the Stripe webhook.
+Native subscription support requires the `validate-iap-receipt` edge function (RevenueCat webhook handler) to be updated to call `setLumynPro` when it receives a subscription entitlement grant for `lumyn_pro`. This is included in §10 step 4. The existing `purchaseProduct` flow is for consumables only — `lumyn-pro` on native uses RevenueCat's subscription offering and entitlement, not the consumable purchase path. The `purchaseProduct` function must be extended or a separate `purchaseSubscription` path added for native subscription products.
 
 ---
 
@@ -95,13 +142,46 @@ RevenueCat entitlement check after purchase sets `lumyn_pro = true` via the same
 
 ### `handleSubscriptionUpdate` addition
 
-After upserting the `subscriptions` row, check if the price is the Lumyn Pro price. If yes, call `setLumynPro(supabase, userId, true, null)`.
+After upserting the `subscriptions` row, check if the price is the Lumyn Pro price using the `LUMYN_PRO_STRIPE_PRICE_ID` env var (set in Supabase secrets, matches the real `stripe_price_id` from §2):
+
+```ts
+const stripePriceId = subscription.items.data[0]?.price.id
+const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
+if (stripePriceId && lumynProPriceId && stripePriceId === lumynProPriceId) {
+  await setLumynPro(supabase, userId, true, null)
+}
+```
+
+`userId` is already resolved in this function via `stripe.customers.retrieve(subscription.customer)` → `customer.metadata.supabase_user_id`.
 
 ### `handleSubscriptionDeleted` addition
 
-Call `setLumynPro(supabase, userId, false, subscription.current_period_end)` — sets `lumyn_pro = false`, `lumyn_pro_until = current_period_end` (grace period until billing cycle ends).
+`handleSubscriptionDeleted` currently only updates the `subscriptions` row — it does **not** resolve a `userId`. It must be updated to perform the same customer lookup that `handleSubscriptionUpdate` already does:
 
-### New DB helper
+```ts
+const customer = await stripe.customers.retrieve(subscription.customer as string)
+const userId = (customer as Stripe.Customer).metadata?.supabase_user_id
+if (!userId) { console.error('No supabase_user_id on customer'); return }
+```
+
+Also check the Lumyn Pro price guard (same as in `handleSubscriptionUpdate`) before calling `setLumynPro`, so other subscription types are not affected:
+
+```ts
+const stripePriceId = subscription.items.data[0]?.price.id
+const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
+if (stripePriceId && lumynProPriceId && stripePriceId === lumynProPriceId) {
+  await setLumynPro(
+    supabase,
+    userId,
+    false,
+    new Date(subscription.current_period_end * 1000).toISOString()  // Unix → ISO
+  )
+}
+```
+
+**Cancellation grace period behaviour:** when a user cancels via the Stripe portal with "cancel at period end", Stripe fires `customer.subscription.updated` (not `deleted`) with `cancel_at_period_end: true`. The user remains `lumyn_pro = true` until the period ends, at which point `customer.subscription.deleted` fires and `setLumynPro(false, period_end)` runs. Because `period_end` is now in the past, `is_pro` becomes false immediately. This is intentional — the grace period window is zero at deletion time.
+
+### `setLumynPro` DB helper
 
 ```ts
 async function setLumynPro(
@@ -112,7 +192,15 @@ async function setLumynPro(
 ): Promise<void>
 ```
 
-Updates `user_profiles` SET `lumyn_pro`, `lumyn_pro_until` WHERE `user_id = userId`.
+Uses **upsert** (not plain UPDATE) to handle the edge case where `user_profiles` row doesn't exist yet:
+
+```ts
+await supabase.from('user_profiles').upsert({
+  user_id: userId,
+  lumyn_pro: isPro,
+  lumyn_pro_until: proUntil,
+}, { onConflict: 'user_id' })
+```
 
 ---
 
@@ -120,26 +208,36 @@ Updates `user_profiles` SET `lumyn_pro`, `lumyn_pro_until` WHERE `user_id = user
 
 ### Step 1 expansion: entitlement check
 
-Before the existing rate limit check, load the user's profile in one query:
+Before the existing rate limit check, call `getUserEntitlement`:
 
 ```ts
-const { lumyn_pro, lumyn_pro_until, lumyn_messages_used } = await getUserEntitlement(supabase, userId)
-const is_pro = lumyn_pro && (lumyn_pro_until === null || new Date(lumyn_pro_until) > new Date())
+const entitlement = await getUserEntitlement(supabase, userId)
+// Returns { lumyn_pro: false, lumyn_pro_until: null, lumyn_messages_used: 0 } if no row exists
+const is_pro = entitlement.lumyn_pro &&
+  (entitlement.lumyn_pro_until === null || new Date(entitlement.lumyn_pro_until) > new Date())
 ```
 
-**If free and `messages_used >= 10`:**
-Return a `ChatResponse` with `paywall: true`. No LLM call, no DB writes beyond the user message insert.
+`getUserEntitlement` selects from `user_profiles` and returns safe defaults if the row doesn't exist (no row = free tier, 0 messages used).
 
-**If free and under limit:**
-`UPDATE user_profiles SET lumyn_messages_used = lumyn_messages_used + 1 WHERE user_id = $1`
+**If free tier:**
 
-Then proceed with rate limit check as today.
+Call `lumyn_increment_free_messages(userId)` atomically:
+- Returns `null` → paywall hit → return `ChatResponse` with `paywall: true`. No LLM call.
+- Returns a number → proceed (messages_used is now incremented).
+
+Then proceed with existing rate limit check (60/hr, 500/day).
+
+**Note:** the `paywall: true` response is returned before inserting the user's message into `lumyn_messages` (Step 3), so no DB record is created for the blocked message.
+
+**Counter drift trade-off (accepted):** `lumyn_messages_used` is incremented atomically at Step 1, before the message is inserted at Step 3. If a transient error occurs between Step 1 and Step 3, the counter advances without a corresponding `lumyn_messages` row. This is accepted — the counter is a soft limit for UX gating, not a billing-critical value. Drift of ±1 is tolerable.
 
 ### `ChatResponse` type addition
 
 ```ts
 paywall?: true
 ```
+
+Add to both `apps/web/src/types/lumyn.ts` and `supabase/functions/lumyn-chat/types.ts`.
 
 ### Free-tier feature gates (applied throughout orchestrator)
 
@@ -158,13 +256,13 @@ paywall?: true
 
 The `LumynChatFab` panel header gains a "Conversations" icon button (left side). Tapping it slides open a thread list drawer within the chat panel (not a new page).
 
+**Data source:** direct Supabase JS client query (anon key + user JWT) to `lumyn_conversations` and `lumyn_messages`. Both tables have RLS `FOR ALL USING (auth.uid() = user_id)` — SELECT is permitted for the authenticated user's own rows. No new edge function is needed.
+
 **Thread list:**
 - Shows up to 10 conversations ordered by `created_at DESC`
 - Each row: title (or `"Conversation · {date}"` fallback), mode badge, date
 - "New conversation" button at top — clears `conversationId` state, clears `chatMessages` state
 - Tapping a thread: fetches its messages from `lumyn_messages` ordered `created_at ASC`, maps to `ChatMessage[]`, sets `conversationId`
-
-**Data source:** direct Supabase client query to `lumyn_conversations` (RLS scopes to `user_id`). No new edge function needed.
 
 **Pro gate on threads:**
 - Free: thread list shows only the single most recent conversation. "New conversation" replaces it (old one becomes inaccessible in UI, not deleted in DB).
@@ -189,7 +287,7 @@ Rendered in the conversation thread when `response.paywall === true`. Styled as 
 Content:
 - "You've used your 10 free messages with Lumyn."
 - "Upgrade to Pro for unlimited conversations, full memory, and all four modes — $14.97/month."
-- "Upgrade to Lumyn Pro" button → `purchaseTier('lumyn-pro', { priceId: LUMYN_PRO_PRICE_ID })`
+- "Upgrade to Lumyn Pro" button → `purchaseTier('lumyn-pro', { priceId: VITE_LUMYN_PRO_PRICE_ID, fullName: '', dob: '' })`
 
 The card is injected into `chatMessages` state client-side (not stored in DB).
 
@@ -197,21 +295,24 @@ The card is injected into `chatMessages` state client-side (not stored in DB).
 
 Sticky banner at the bottom of the thread drawer for free users:
 - "Unlock full conversation history with Pro."
-- "Upgrade" CTA button
+- "Upgrade" CTA button → same `purchaseTier` call as above.
 
 ### Post-purchase flow
 
 - Stripe redirects to `/payment/success?upgraded=true`
-- Success page shows toast: "Welcome to Lumyn Pro — enjoy unlimited conversations."
-- On next chat open, client re-fetches user profile; `lumyn_pro = true` lifts all gates automatically.
+- Success page shows toast: "Welcome to Lumyn Pro — enjoy unlimited conversations." (triggered by `upgraded=true` query param)
+- Success page displays subscription copy, not reading credits (requires a `lumyn-pro` case in the existing tier label switch)
+- On next chat open, `useLumynEntitlement` re-fetches; `lumyn_pro = true` lifts all gates automatically
 
 ---
 
 ## §8 — Client entitlement hook
 
-New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` from `user_profiles` on mount. Returns `{ isPro, messagesUsed, isLoading }`. Used by `LumynChatFab` to:
+New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` from `user_profiles` on mount via direct Supabase client query. Returns `{ isPro, messagesUsed, isLoading }`. Used by `LumynChatFab` to:
 - Show/hide Pro upgrade banner in thread list
 - Know whether to show the thread switcher in full or restricted mode
+
+**Staleness (accepted):** the hook fetches once on mount. If a subscription is cancelled mid-session, the client UI remains in Pro state until the user remounts or reloads. The server-side orchestrator is the true enforcement point — a cancelled user cannot send messages even if the client UI doesn't update. Stale client state is a UX gap, not a security gap, and is accepted for this release. A Supabase Realtime subscription on `user_profiles` is deferred to a future iteration.
 
 ---
 
@@ -227,13 +328,13 @@ New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` f
 
 ## §10 — Implementation order
 
-1. DB migration (`user_profiles` columns + Lumyn Pro product/price seed)
-2. `setLumynPro` helper + stripe-webhook additions
-3. `create-checkout-session` subscription mode branch
-4. IAP product ID addition
-5. Orchestrator entitlement check + free-tier gates + `paywall` response field
-6. `useLumynEntitlement` hook
-7. Thread switcher UI (`LumynChatFab` + thread list drawer)
-8. `LumynPaywallCard` component + inline upsell injection
-9. Thread list Pro banner
-10. Post-purchase toast on `/payment/success`
+1. DB migration: `user_profiles` columns + `lumyn_increment_free_messages` RPC + Lumyn Pro product/price seed
+2. `setLumynPro` helper (upsert) + stripe-webhook additions (`handleSubscriptionUpdate` + `handleSubscriptionDeleted` with customer lookup)
+3. `create-checkout-session` subscription mode branch (conditional `payment_intent_data` / `subscription_data`, `lumyn-pro` case in `/payment/success`)
+4. IAP: add product ID to `TIER_TO_PRODUCT_ID`; add `purchaseSubscription` native path for subscription products; update `validate-iap-receipt` to call `setLumynPro` on entitlement grant
+5. Orchestrator: `getUserEntitlement`, atomic free-message gate, free-tier feature gates, `paywall` response field
+6. `ChatResponse` type update (both `types.ts` files)
+7. `useLumynEntitlement` hook
+8. Thread switcher UI (`LumynChatFab` + thread list drawer)
+9. `LumynPaywallCard` component + inline upsell injection
+10. Thread list Pro banner + post-purchase toast on `/payment/success`

--- a/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
+++ b/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
@@ -1,0 +1,239 @@
+# Lumyn Pro Subscription — Design Spec
+
+**Date:** 2026-03-19
+**Status:** Approved
+
+---
+
+## Overview
+
+Lumyn Pro is a $14.97/month recurring subscription that unlocks the full Lumyn experience. Free users get 10 lifetime messages in reflect mode only, with stateless context. Pro users get unlimited conversations, persistent memory (claims, moments, summaries), all four modes, reading history in every conversation, and full thread history.
+
+---
+
+## §1 — Data Model
+
+### `user_profiles` additions (migration)
+
+```sql
+ALTER TABLE user_profiles
+  ADD COLUMN lumyn_pro           BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN lumyn_pro_until     TIMESTAMPTZ,
+  ADD COLUMN lumyn_messages_used INTEGER NOT NULL DEFAULT 0;
+```
+
+- `lumyn_pro` — live entitlement gate, set by Stripe webhook
+- `lumyn_pro_until` — NULL for active managed subscriptions; set to `current_period_end` on cancellation (grace period support)
+- `lumyn_messages_used` — monotonic counter, incremented on each free-tier message send, never decremented
+
+### Entitlement rule (server-side)
+
+```
+is_pro = lumyn_pro AND (lumyn_pro_until IS NULL OR lumyn_pro_until > now())
+```
+
+### Free tier limits
+
+| Limit | Value |
+|---|---|
+| Total messages (lifetime) | 10 |
+| Mode | `reflect` only |
+| Memory persistence | None (claims/moments/summaries skipped) |
+| Reading history in context | Stripped |
+| Thread history | Most recent conversation only |
+
+---
+
+## §2 — Stripe Product & Seeding
+
+New migration seeds one product and one recurring price:
+
+```sql
+INSERT INTO products (stripe_product_id, name, description, active)
+VALUES ('prod_lumyn_pro', 'Lumyn Pro', 'Unlimited Lumyn conversations with full memory and all modes', true);
+
+INSERT INTO prices (product_id, stripe_price_id, currency, unit_amount, interval, interval_count, active)
+VALUES (
+  (SELECT id FROM products WHERE stripe_product_id = 'prod_lumyn_pro'),
+  'price_lumyn_pro_monthly',
+  'usd',
+  1497,      -- $14.97
+  'month',
+  1,
+  true
+);
+```
+
+> Real Stripe product/price IDs replace the placeholders above before deploy.
+
+---
+
+## §3 — Checkout Flow
+
+### Web (`create-checkout-session`)
+
+When `tier === 'lumyn-pro'`, use `mode: 'subscription'` instead of `mode: 'payment'`. All other logic (customer lookup/create, metadata, success/cancel URLs) is unchanged.
+
+```ts
+mode: tier === 'lumyn-pro' ? 'subscription' : 'payment',
+```
+
+Success URL receives `?session_id={CHECKOUT_SESSION_ID}`. The existing `/payment/success` page handles this. Add `?upgraded=true` param to trigger a Pro welcome toast when the user lands back in the app.
+
+### Native IAP (`iap.ts`)
+
+Add to `TIER_TO_PRODUCT_ID`:
+```ts
+'lumyn-pro': 'com.vyberology.lumyn_pro'
+```
+
+RevenueCat entitlement check after purchase sets `lumyn_pro = true` via the same `setLumynPro` DB helper called by the Stripe webhook.
+
+---
+
+## §4 — Stripe Webhook
+
+### `handleSubscriptionUpdate` addition
+
+After upserting the `subscriptions` row, check if the price is the Lumyn Pro price. If yes, call `setLumynPro(supabase, userId, true, null)`.
+
+### `handleSubscriptionDeleted` addition
+
+Call `setLumynPro(supabase, userId, false, subscription.current_period_end)` — sets `lumyn_pro = false`, `lumyn_pro_until = current_period_end` (grace period until billing cycle ends).
+
+### New DB helper
+
+```ts
+async function setLumynPro(
+  supabase: SupabaseClient,
+  userId: string,
+  isPro: boolean,
+  proUntil: string | null   // ISO timestamp or null
+): Promise<void>
+```
+
+Updates `user_profiles` SET `lumyn_pro`, `lumyn_pro_until` WHERE `user_id = userId`.
+
+---
+
+## §5 — Orchestrator Changes
+
+### Step 1 expansion: entitlement check
+
+Before the existing rate limit check, load the user's profile in one query:
+
+```ts
+const { lumyn_pro, lumyn_pro_until, lumyn_messages_used } = await getUserEntitlement(supabase, userId)
+const is_pro = lumyn_pro && (lumyn_pro_until === null || new Date(lumyn_pro_until) > new Date())
+```
+
+**If free and `messages_used >= 10`:**
+Return a `ChatResponse` with `paywall: true`. No LLM call, no DB writes beyond the user message insert.
+
+**If free and under limit:**
+`UPDATE user_profiles SET lumyn_messages_used = lumyn_messages_used + 1 WHERE user_id = $1`
+
+Then proceed with rate limit check as today.
+
+### `ChatResponse` type addition
+
+```ts
+paywall?: true
+```
+
+### Free-tier feature gates (applied throughout orchestrator)
+
+| Gate | Free behaviour |
+|---|---|
+| Mode | Coerce any non-`reflect` mode to `reflect` silently |
+| `vyberologyContext` | Strip `ReadingHistory` and `UserProfile` inputs before prompt assembly |
+| Memory write (step 7–8) | Skip `processMemorableMoments` and `generateConversationSummary` entirely |
+| Claims/patterns | Not written or read for free users |
+
+---
+
+## §6 — Thread UI
+
+### Thread switcher
+
+The `LumynChatFab` panel header gains a "Conversations" icon button (left side). Tapping it slides open a thread list drawer within the chat panel (not a new page).
+
+**Thread list:**
+- Shows up to 10 conversations ordered by `created_at DESC`
+- Each row: title (or `"Conversation · {date}"` fallback), mode badge, date
+- "New conversation" button at top — clears `conversationId` state, clears `chatMessages` state
+- Tapping a thread: fetches its messages from `lumyn_messages` ordered `created_at ASC`, maps to `ChatMessage[]`, sets `conversationId`
+
+**Data source:** direct Supabase client query to `lumyn_conversations` (RLS scopes to `user_id`). No new edge function needed.
+
+**Pro gate on threads:**
+- Free: thread list shows only the single most recent conversation. "New conversation" replaces it (old one becomes inaccessible in UI, not deleted in DB).
+- Pro: full history up to 10 shown, unlimited new conversations.
+
+### State additions to `LumynChatFab`
+
+```ts
+const [showThreadList, setShowThreadList] = useState(false)
+const [threads, setThreads] = useState<LumynConversation[]>([])
+const [isLoadingThreads, setIsLoadingThreads] = useState(false)
+```
+
+---
+
+## §7 — Upsell UI
+
+### Inline paywall card
+
+Rendered in the conversation thread when `response.paywall === true`. Styled as an assistant message bubble but implemented as a dedicated `LumynPaywallCard` component.
+
+Content:
+- "You've used your 10 free messages with Lumyn."
+- "Upgrade to Pro for unlimited conversations, full memory, and all four modes — $14.97/month."
+- "Upgrade to Lumyn Pro" button → `purchaseTier('lumyn-pro', { priceId: LUMYN_PRO_PRICE_ID })`
+
+The card is injected into `chatMessages` state client-side (not stored in DB).
+
+### Thread list Pro banner
+
+Sticky banner at the bottom of the thread drawer for free users:
+- "Unlock full conversation history with Pro."
+- "Upgrade" CTA button
+
+### Post-purchase flow
+
+- Stripe redirects to `/payment/success?upgraded=true`
+- Success page shows toast: "Welcome to Lumyn Pro — enjoy unlimited conversations."
+- On next chat open, client re-fetches user profile; `lumyn_pro = true` lifts all gates automatically.
+
+---
+
+## §8 — Client entitlement hook
+
+New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` from `user_profiles` on mount. Returns `{ isPro, messagesUsed, isLoading }`. Used by `LumynChatFab` to:
+- Show/hide Pro upgrade banner in thread list
+- Know whether to show the thread switcher in full or restricted mode
+
+---
+
+## §9 — Out of scope
+
+- Trial periods
+- Annual billing
+- Team/gift subscriptions
+- Internationalised pricing
+- RevenueCat subscription status sync (beyond setting the DB flag) — deferred
+
+---
+
+## §10 — Implementation order
+
+1. DB migration (`user_profiles` columns + Lumyn Pro product/price seed)
+2. `setLumynPro` helper + stripe-webhook additions
+3. `create-checkout-session` subscription mode branch
+4. IAP product ID addition
+5. Orchestrator entitlement check + free-tier gates + `paywall` response field
+6. `useLumynEntitlement` hook
+7. Thread switcher UI (`LumynChatFab` + thread list drawer)
+8. `LumynPaywallCard` component + inline upsell injection
+9. Thread list Pro banner
+10. Post-purchase toast on `/payment/success`

--- a/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
+++ b/docs/superpowers/specs/2026-03-19-lumyn-pro-subscription-design.md
@@ -19,20 +19,36 @@ Lumyn Pro is a $14.97/month recurring subscription that unlocks the full Lumyn e
 ALTER TABLE user_profiles
   ADD COLUMN lumyn_pro           BOOLEAN NOT NULL DEFAULT false,
   ADD COLUMN lumyn_pro_until     TIMESTAMPTZ,
-  ADD COLUMN lumyn_messages_used INTEGER NOT NULL DEFAULT 0;
+  ADD COLUMN lumyn_messages_used INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN lumyn_last_message_at TIMESTAMPTZ;  -- maintained on each message insert
 ```
 
 - `lumyn_pro` — live entitlement gate, set by Stripe webhook
-- `lumyn_pro_until` — NULL for active managed subscriptions; set to `current_period_end` on cancellation (grace period support)
-- `lumyn_messages_used` — monotonic counter, incremented atomically on each free-tier message send via a DB function, never decremented
+- `lumyn_pro_until` — NULL for active managed subscriptions; set to `current_period_end` on cancellation
+- `lumyn_messages_used` — monotonic counter, incremented atomically on each free-tier message send, never decremented
+- `lumyn_last_message_at` — updated on every message send (used for thread ordering, see §6)
 
 **Existing users:** the migration adds `lumyn_messages_used = 0` for all existing rows. Historical messages in `lumyn_messages` are not counted toward the free limit — everyone starts fresh post-migration.
 
-### Entitlement rule (server-side)
+### Entitlement rule
 
+The entitlement check is centralised in one place and called everywhere — not duplicated:
+
+**Server-side (orchestrator):** `resolveLumynEntitlement(profile)` helper in `db.ts`:
+
+```ts
+export function resolveLumynEntitlement(profile: {
+  lumyn_pro: boolean
+  lumyn_pro_until: string | null
+}): boolean {
+  return profile.lumyn_pro &&
+    (profile.lumyn_pro_until === null || new Date(profile.lumyn_pro_until) > new Date())
+}
 ```
-is_pro = lumyn_pro AND (lumyn_pro_until IS NULL OR lumyn_pro_until > now())
-```
+
+Used in the orchestrator, `setLumynPro`, and any future server path. No hand-rolled entitlement logic elsewhere.
+
+**Client-side:** `useLumynEntitlement` hook derives `isPro` using the same rule from the fetched profile row.
 
 ### Free tier limits
 
@@ -42,11 +58,13 @@ is_pro = lumyn_pro AND (lumyn_pro_until IS NULL OR lumyn_pro_until > now())
 | Mode | `reflect` only |
 | Memory persistence | None (claims/moments/summaries skipped) |
 | Reading history in context | Stripped |
-| Thread history | Most recent conversation only |
+| Thread history | Most recent conversation only (by last activity) |
+
+### Free message counter — UI display
+
+Free users see a message counter in the `LumynChatFab` header: **"3 / 10 free messages"**. This reduces surprise at the paywall. `useLumynEntitlement` returns `messagesUsed` for this.
 
 ### Atomic free-message increment (DB function — part of §1 migration)
-
-To prevent race conditions (two concurrent requests both passing the 10-message guard), the increment is handled by a single SQL function:
 
 ```sql
 CREATE OR REPLACE FUNCTION lumyn_increment_free_messages(p_user_id UUID)
@@ -59,12 +77,14 @@ BEGIN
       AND lumyn_messages_used < 10
       AND lumyn_pro = false
     RETURNING lumyn_messages_used INTO v_new_count;
-  RETURN v_new_count; -- NULL if 0 rows updated (limit already hit or now Pro)
+  RETURN v_new_count; -- NULL if 0 rows updated (limit hit or now Pro)
 END;
 $$;
 ```
 
-The orchestrator calls this function instead of a read-then-update. A NULL return means the paywall is hit.
+A NULL return means the paywall is hit. The orchestrator calls this instead of a read-then-update.
+
+**Idempotency note:** client retries and double-submits are a known risk. For alpha, this is accepted. A future iteration can add an optional `client_message_id` idempotency key — if the same user sends the same key within a short window, the increment is skipped.
 
 ---
 
@@ -88,7 +108,7 @@ VALUES (
 );
 ```
 
-> Real Stripe product/price IDs replace the placeholders above before deploy. The real `stripe_price_id` is also set in Vercel/hosting env as `VITE_LUMYN_PRO_PRICE_ID` (used client-side by `LumynPaywallCard` to call `purchaseTier`).
+> Real Stripe product/price IDs replace the placeholders above before deploy. The real `stripe_price_id` is also set in Vercel/hosting env as `VITE_LUMYN_PRO_PRICE_ID` (used client-side by `LumynPaywallCard`), and in Supabase secrets as `LUMYN_PRO_STRIPE_PRICE_ID` (used server-side by the webhook).
 
 ---
 
@@ -96,7 +116,7 @@ VALUES (
 
 ### Web (`create-checkout-session`)
 
-When `tier === 'lumyn-pro'`, use `mode: 'subscription'` instead of `mode: 'payment'`. **Critically:** `payment_intent_data` is invalid in subscription mode — it must be conditionally omitted. Use `subscription_data` instead for metadata in the subscription case:
+When `tier === 'lumyn-pro'`, use `mode: 'subscription'` instead of `mode: 'payment'`. **`payment_intent_data` is invalid in subscription mode** — it must be conditionally omitted. Use `subscription_data` for metadata instead:
 
 ```ts
 const isSubscription = tier === 'lumyn-pro'
@@ -115,13 +135,16 @@ const sessionParams = {
 }
 ```
 
-Success URL: `/payment/success?session_id={CHECKOUT_SESSION_ID}&upgraded=true&tier=lumyn-pro` — the `upgraded=true` param triggers the Pro welcome toast; `tier=lumyn-pro` is read by the existing tier label switch in `PaymentSuccess.tsx`.
+Success URL: `/payment/success?session_id={CHECKOUT_SESSION_ID}&upgraded=true&tier=lumyn-pro`
 
-**`/payment/success` page:** add a `lumyn-pro` case to the tier label switch so the page shows subscription-appropriate copy (not "reading credits"). The `tier` param must be included in the success URL (above) — it is not derived from the Stripe session server-side.
+**`/payment/success` page changes:**
+- Add a `lumyn-pro` case to the tier label switch (subscription copy, not reading credits)
+- On mount, if `upgraded=true` param is present: re-fetch `useLumynEntitlement` immediately before showing the toast — this ensures the Pro state is reflected in the UI without waiting for the next page load
+- Toast: "Welcome to Lumyn Pro — enjoy unlimited conversations."
 
 ### `purchaseTier` signature
 
-`purchaseTier` requires `{ fullName, dob, priceId }`. For `lumyn-pro`, `fullName` and `dob` are irrelevant — pass empty strings. The `create-checkout-session` function only uses them as metadata, and they are not required by Stripe:
+`purchaseTier` requires `{ fullName, dob, priceId }`. For `lumyn-pro`, pass empty strings for `fullName`/`dob`:
 
 ```ts
 purchaseTier('lumyn-pro', { priceId: LUMYN_PRO_PRICE_ID, fullName: '', dob: '' })
@@ -134,102 +157,106 @@ Add to `TIER_TO_PRODUCT_ID`:
 'lumyn-pro': 'com.vyberology.lumyn_pro'
 ```
 
-Native subscription support requires the `validate-iap-receipt` edge function (RevenueCat webhook handler) to be updated to call `setLumynPro` when it receives a subscription entitlement grant for `lumyn_pro`. This is included in §10 step 4. The existing `purchaseProduct` flow is for consumables only — `lumyn-pro` on native uses RevenueCat's subscription offering and entitlement, not the consumable purchase path. The `purchaseProduct` function must be extended or a separate `purchaseSubscription` path added for native subscription products.
+**Native subscription is web-first for the initial rollout.** The native purchase path for `lumyn-pro` must use RevenueCat's subscription offering (`Purchases.purchasePackage`), not the existing consumable `purchaseProduct` flow. A separate `purchaseSubscription(productId)` function is required. The `validate-iap-receipt` webhook must be updated to call `setLumynPro` on `INITIAL_PURCHASE` and `RENEWAL` entitlement events for the `lumyn_pro` entitlement identifier. This work is included in §10 step 4 but the native Lumyn Pro purchase UI should remain hidden/disabled until fully tested on device.
 
 ---
 
 ## §4 — Stripe Webhook
 
-### `handleSubscriptionUpdate` addition
+### Price match helper
 
-After upserting the `subscriptions` row, check if the price is the Lumyn Pro price using the `LUMYN_PRO_STRIPE_PRICE_ID` env var (set in Supabase secrets, matches the real `stripe_price_id` from §2):
+Both `handleSubscriptionUpdate` and `handleSubscriptionDeleted` use the same price check. Extract to a shared helper to avoid duplication:
 
 ```ts
-const stripePriceId = subscription.items.data[0]?.price.id
-const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
-if (stripePriceId && lumynProPriceId && stripePriceId === lumynProPriceId) {
+function isLumynProPrice(subscription: Stripe.Subscription): boolean {
+  const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
+  if (!lumynProPriceId) return false
+  return subscription.items.data.some(item => item.price.id === lumynProPriceId)
+}
+```
+
+Note: checks **any** line item, not just `[0]`, for robustness against multi-item subscriptions.
+
+### `handleSubscriptionUpdate` addition
+
+After upserting the `subscriptions` row:
+
+```ts
+if (isLumynProPrice(subscription)) {
   await setLumynPro(supabase, userId, true, null)
 }
 ```
 
-`userId` is already resolved in this function via `stripe.customers.retrieve(subscription.customer)` → `customer.metadata.supabase_user_id`.
+`userId` is already resolved via `stripe.customers.retrieve(subscription.customer)` → `customer.metadata.supabase_user_id`.
 
 ### `handleSubscriptionDeleted` addition
 
-`handleSubscriptionDeleted` currently only updates the `subscriptions` row — it does **not** resolve a `userId`. It must be updated to perform the same customer lookup that `handleSubscriptionUpdate` already does:
+`handleSubscriptionDeleted` currently has no customer lookup — it must add one (mirrors `handleSubscriptionUpdate`):
 
 ```ts
 const customer = await stripe.customers.retrieve(subscription.customer as string)
 const userId = (customer as Stripe.Customer).metadata?.supabase_user_id
 if (!userId) { console.error('No supabase_user_id on customer'); return }
-```
 
-Also check the Lumyn Pro price guard (same as in `handleSubscriptionUpdate`) before calling `setLumynPro`, so other subscription types are not affected:
-
-```ts
-const stripePriceId = subscription.items.data[0]?.price.id
-const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
-if (stripePriceId && lumynProPriceId && stripePriceId === lumynProPriceId) {
+if (isLumynProPrice(subscription)) {
   await setLumynPro(
     supabase,
     userId,
     false,
-    new Date(subscription.current_period_end * 1000).toISOString()  // Unix → ISO
+    new Date(subscription.current_period_end * 1000).toISOString()
   )
 }
 ```
 
-**Cancellation grace period behaviour:** when a user cancels via the Stripe portal with "cancel at period end", Stripe fires `customer.subscription.updated` (not `deleted`) with `cancel_at_period_end: true`. The user remains `lumyn_pro = true` until the period ends, at which point `customer.subscription.deleted` fires and `setLumynPro(false, period_end)` runs. Because `period_end` is now in the past, `is_pro` becomes false immediately. This is intentional — the grace period window is zero at deletion time.
+**Cancellation grace period:** user cancels → `customer.subscription.updated` fires with `cancel_at_period_end: true` → `lumyn_pro` stays `true`. At period end → `customer.subscription.deleted` fires → `setLumynPro(false, period_end)` → `period_end` is now past → `is_pro` resolves false immediately. Grace period is zero at deletion time. Intentional.
 
 ### `setLumynPro` DB helper
+
+Uses upsert (not plain UPDATE) so it is safe if the `user_profiles` row doesn't exist. **Only touches `lumyn_pro` and `lumyn_pro_until` columns** — all other profile fields are left untouched via the upsert merge:
 
 ```ts
 async function setLumynPro(
   supabase: SupabaseClient,
   userId: string,
   isPro: boolean,
-  proUntil: string | null   // ISO timestamp or null
-): Promise<void>
+  proUntil: string | null
+): Promise<void> {
+  const { error } = await supabase.from('user_profiles').upsert({
+    user_id: userId,
+    lumyn_pro: isPro,
+    lumyn_pro_until: proUntil,
+  }, { onConflict: 'user_id' })
+  if (error) console.error('setLumynPro failed:', error)
+}
 ```
 
-Uses **upsert** (not plain UPDATE) to handle the edge case where `user_profiles` row doesn't exist yet:
-
-```ts
-await supabase.from('user_profiles').upsert({
-  user_id: userId,
-  lumyn_pro: isPro,
-  lumyn_pro_until: proUntil,
-}, { onConflict: 'user_id' })
-```
+Supabase upsert with `onConflict` only updates the specified columns on conflict — existing columns not in the object are preserved.
 
 ---
 
 ## §5 — Orchestrator Changes
 
-### Step 1 expansion: entitlement check
-
-Before the existing rate limit check, call `getUserEntitlement`:
+### Entitlement check (before Step 1 rate limit)
 
 ```ts
 const entitlement = await getUserEntitlement(supabase, userId)
-// Returns { lumyn_pro: false, lumyn_pro_until: null, lumyn_messages_used: 0 } if no row exists
-const is_pro = entitlement.lumyn_pro &&
-  (entitlement.lumyn_pro_until === null || new Date(entitlement.lumyn_pro_until) > new Date())
+// Safe defaults if no row: { lumyn_pro: false, lumyn_pro_until: null, lumyn_messages_used: 0 }
+const is_pro = resolveLumynEntitlement(entitlement)
 ```
-
-`getUserEntitlement` selects from `user_profiles` and returns safe defaults if the row doesn't exist (no row = free tier, 0 messages used).
 
 **If free tier:**
 
 Call `lumyn_increment_free_messages(userId)` atomically:
-- Returns `null` → paywall hit → return `ChatResponse` with `paywall: true`. No LLM call.
-- Returns a number → proceed (messages_used is now incremented).
+- Returns `null` → paywall hit → return `ChatResponse` with `paywall: true`. No LLM call, no message insert.
+- Returns a number → proceed (counter incremented).
 
 Then proceed with existing rate limit check (60/hr, 500/day).
 
-**Note:** the `paywall: true` response is returned before inserting the user's message into `lumyn_messages` (Step 3), so no DB record is created for the blocked message.
+**Counter drift (accepted):** counter increments at this step; message insert happens at Step 3. A transient error between steps causes drift of ±1. Accepted — this is a UX soft limit, not billing-critical.
 
-**Counter drift trade-off (accepted):** `lumyn_messages_used` is incremented atomically at Step 1, before the message is inserted at Step 3. If a transient error occurs between Step 1 and Step 3, the counter advances without a corresponding `lumyn_messages` row. This is accepted — the counter is a soft limit for UX gating, not a billing-critical value. Drift of ±1 is tolerable.
+### Paywall event logging
+
+When `paywall: true` is returned, log a row to `lumyn_safety_events` with `event_type = 'paywall_hit'` and `details = { messages_used, mode_requested }`. This provides funnel analytics and "did we block too early?" signal.
 
 ### `ChatResponse` type addition
 
@@ -239,33 +266,37 @@ paywall?: true
 
 Add to both `apps/web/src/types/lumyn.ts` and `supabase/functions/lumyn-chat/types.ts`.
 
-### Free-tier feature gates (applied throughout orchestrator)
+### Free-tier feature gates
 
 | Gate | Free behaviour |
 |---|---|
 | Mode | Coerce any non-`reflect` mode to `reflect` silently |
 | `vyberologyContext` | Strip `ReadingHistory` and `UserProfile` inputs before prompt assembly |
-| Memory write (step 7–8) | Skip `processMemorableMoments` and `generateConversationSummary` entirely |
+| Memory write (steps 7–8) | Skip `processMemorableMoments` and `generateConversationSummary` entirely |
 | Claims/patterns | Not written or read for free users |
 
 ---
 
 ## §6 — Thread UI
 
+### Thread ordering
+
+Threads are ordered by **last activity** — `MAX(lumyn_messages.created_at)` per conversation, falling back to `lumyn_conversations.created_at`. The `lumyn_last_message_at` column on `user_profiles` (§1) is updated on each message insert and used as the sort key for the single-thread free view. For the thread list, order by `lumyn_conversations.created_at DESC` (sufficient for alpha; a `last_message_at` column on `lumyn_conversations` can be added later if needed).
+
 ### Thread switcher
 
-The `LumynChatFab` panel header gains a "Conversations" icon button (left side). Tapping it slides open a thread list drawer within the chat panel (not a new page).
+The `LumynChatFab` panel header gains a "Conversations" icon button (left side). Tapping it slides open a thread list drawer within the chat panel.
 
-**Data source:** direct Supabase JS client query (anon key + user JWT) to `lumyn_conversations` and `lumyn_messages`. Both tables have RLS `FOR ALL USING (auth.uid() = user_id)` — SELECT is permitted for the authenticated user's own rows. No new edge function is needed.
+**Data source:** direct Supabase JS client query to `lumyn_conversations` (RLS: `FOR ALL USING (auth.uid() = user_id)`). No new edge function needed.
 
 **Thread list:**
 - Shows up to 10 conversations ordered by `created_at DESC`
 - Each row: title (or `"Conversation · {date}"` fallback), mode badge, date
 - "New conversation" button at top — clears `conversationId` state, clears `chatMessages` state
-- Tapping a thread: fetches its messages from `lumyn_messages` ordered `created_at ASC`, maps to `ChatMessage[]`, sets `conversationId`
+- Tapping a thread: fetches `lumyn_messages` for that `conversation_id` ordered `created_at ASC`, maps to `ChatMessage[]`, sets `conversationId`
 
 **Pro gate on threads:**
-- Free: thread list shows only the single most recent conversation. "New conversation" replaces it (old one becomes inaccessible in UI, not deleted in DB).
+- Free: thread list shows only the single most recent conversation (by `created_at DESC LIMIT 1`). "New conversation" creates a new one; old one becomes inaccessible in UI, not deleted.
 - Pro: full history up to 10 shown, unlimited new conversations.
 
 ### State additions to `LumynChatFab`
@@ -280,39 +311,41 @@ const [isLoadingThreads, setIsLoadingThreads] = useState(false)
 
 ## §7 — Upsell UI
 
-### Inline paywall card
+### Free message counter
 
-Rendered in the conversation thread when `response.paywall === true`. Styled as an assistant message bubble but implemented as a dedicated `LumynPaywallCard` component.
+Displayed in the `LumynChatFab` panel header for free users: **"3 / 10 free messages"**. Hidden for Pro users.
+
+### Inline paywall card (`LumynPaywallCard`)
+
+Injected into the conversation thread as a synthetic `ChatMessage` when `response.paywall === true`. Styled as an assistant bubble but not stored in DB.
 
 Content:
 - "You've used your 10 free messages with Lumyn."
 - "Upgrade to Pro for unlimited conversations, full memory, and all four modes — $14.97/month."
 - "Upgrade to Lumyn Pro" button → `purchaseTier('lumyn-pro', { priceId: VITE_LUMYN_PRO_PRICE_ID, fullName: '', dob: '' })`
 
-The card is injected into `chatMessages` state client-side (not stored in DB).
-
 ### Thread list Pro banner
 
-Sticky banner at the bottom of the thread drawer for free users:
+Sticky banner at bottom of the thread drawer for free users:
 - "Unlock full conversation history with Pro."
-- "Upgrade" CTA button → same `purchaseTier` call as above.
+- "Upgrade" CTA → same `purchaseTier` call.
 
 ### Post-purchase flow
 
-- Stripe redirects to `/payment/success?upgraded=true`
-- Success page shows toast: "Welcome to Lumyn Pro — enjoy unlimited conversations." (triggered by `upgraded=true` query param)
-- Success page displays subscription copy, not reading credits (requires a `lumyn-pro` case in the existing tier label switch)
-- On next chat open, `useLumynEntitlement` re-fetches; `lumyn_pro = true` lifts all gates automatically
+1. Stripe redirects to `/payment/success?upgraded=true&tier=lumyn-pro`
+2. On mount, `/payment/success` detects `upgraded=true` → immediately re-fetches `useLumynEntitlement` (not deferred to next page load)
+3. After re-fetch resolves: show toast "Welcome to Lumyn Pro — enjoy unlimited conversations."
+4. Display subscription-appropriate copy (not reading credits) via `lumyn-pro` case in tier label switch
 
 ---
 
 ## §8 — Client entitlement hook
 
-New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` from `user_profiles` on mount via direct Supabase client query. Returns `{ isPro, messagesUsed, isLoading }`. Used by `LumynChatFab` to:
-- Show/hide Pro upgrade banner in thread list
-- Know whether to show the thread switcher in full or restricted mode
+`useLumynEntitlement()` — fetches `lumyn_pro`, `lumyn_pro_until`, `lumyn_messages_used` from `user_profiles` on mount. Returns `{ isPro, messagesUsed, isLoading, refetch }`.
 
-**Staleness (accepted):** the hook fetches once on mount. If a subscription is cancelled mid-session, the client UI remains in Pro state until the user remounts or reloads. The server-side orchestrator is the true enforcement point — a cancelled user cannot send messages even if the client UI doesn't update. Stale client state is a UX gap, not a security gap, and is accepted for this release. A Supabase Realtime subscription on `user_profiles` is deferred to a future iteration.
+`refetch` is exposed so `/payment/success` can trigger an immediate re-fetch after upgrade (§7).
+
+**Staleness (accepted):** fetches once on mount. Mid-session cancellation leaves UI stale until remount. Server enforces — stale client state is a UX gap, not a security gap. Supabase Realtime on `user_profiles` deferred to a future iteration.
 
 ---
 
@@ -322,19 +355,21 @@ New hook: `useLumynEntitlement()` — reads `lumyn_pro`, `lumyn_messages_used` f
 - Annual billing
 - Team/gift subscriptions
 - Internationalised pricing
-- RevenueCat subscription status sync (beyond setting the DB flag) — deferred
+- Client-side idempotency keys for message sends
+- Supabase Realtime entitlement sync
+- Native Lumyn Pro purchase UI (code-ready but hidden pending device testing)
 
 ---
 
 ## §10 — Implementation order
 
-1. DB migration: `user_profiles` columns + `lumyn_increment_free_messages` RPC + Lumyn Pro product/price seed
-2. `setLumynPro` helper (upsert) + stripe-webhook additions (`handleSubscriptionUpdate` + `handleSubscriptionDeleted` with customer lookup)
-3. `create-checkout-session` subscription mode branch (conditional `payment_intent_data` / `subscription_data`, `lumyn-pro` case in `/payment/success`)
-4. IAP: add product ID to `TIER_TO_PRODUCT_ID`; add `purchaseSubscription` native path for subscription products; update `validate-iap-receipt` to call `setLumynPro` on entitlement grant
-5. Orchestrator: `getUserEntitlement`, atomic free-message gate, free-tier feature gates, `paywall` response field
-6. `ChatResponse` type update (both `types.ts` files)
-7. `useLumynEntitlement` hook
-8. Thread switcher UI (`LumynChatFab` + thread list drawer)
+1. DB migration: `user_profiles` columns (`lumyn_pro`, `lumyn_pro_until`, `lumyn_messages_used`, `lumyn_last_message_at`) + `lumyn_increment_free_messages` RPC + Lumyn Pro product/price seed
+2. `resolveLumynEntitlement` shared helper + `setLumynPro` upsert helper + stripe-webhook additions (`isLumynProPrice`, `handleSubscriptionUpdate` guard, `handleSubscriptionDeleted` customer lookup + guard)
+3. `create-checkout-session` subscription mode branch (conditional `payment_intent_data` / `subscription_data`)
+4. IAP: `TIER_TO_PRODUCT_ID` entry + `purchaseSubscription` native path + `validate-iap-receipt` entitlement update (native UI hidden until tested)
+5. `ChatResponse` type update (both `types.ts` files: add `paywall?: true`)
+6. Orchestrator: `getUserEntitlement`, `resolveLumynEntitlement`, atomic free-message gate, paywall event logging, free-tier feature gates
+7. `useLumynEntitlement` hook (with `refetch`)
+8. Thread switcher UI (`LumynChatFab` + thread list drawer + free message counter in header)
 9. `LumynPaywallCard` component + inline upsell injection
-10. Thread list Pro banner + post-purchase toast on `/payment/success`
+10. Thread list Pro banner + `/payment/success` upgrade flow (`lumyn-pro` tier label, immediate entitlement re-fetch, welcome toast)

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -95,6 +95,8 @@ serve(async (req) => {
     }
 
     // Create the checkout session
+    const isSubscription = tier === 'lumyn-pro'
+
     const session = await stripe.checkout.sessions.create({
       customer: customerId,
       line_items: [
@@ -103,8 +105,8 @@ serve(async (req) => {
           quantity,
         },
       ],
-      mode: 'payment', // For one-time payments. Use 'subscription' for recurring
-      success_url: successUrl || `${req.headers.get('origin')}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
+      mode: isSubscription ? 'subscription' : 'payment',
+      success_url: successUrl || `${req.headers.get('origin')}/payment/success?session_id={CHECKOUT_SESSION_ID}${isSubscription ? '&upgraded=true&tier=lumyn-pro' : ''}`,
       cancel_url: cancelUrl || `${req.headers.get('origin')}/payment/cancel`,
       metadata: {
         user_id: user.id,
@@ -113,12 +115,16 @@ serve(async (req) => {
         ...(dob && { dob }),
       },
       billing_address_collection: 'auto',
-      payment_intent_data: {
-        metadata: {
-          user_id: user.id,
-          ...(tier && { tier }),
-        },
-      },
+      ...(isSubscription
+        ? { subscription_data: { metadata: { user_id: user.id, tier } } }
+        : {
+            payment_intent_data: {
+              metadata: {
+                user_id: user.id,
+                ...(tier && { tier }),
+              },
+            },
+          }),
     });
 
     return new Response(

--- a/supabase/functions/lumyn-chat/db.ts
+++ b/supabase/functions/lumyn-chat/db.ts
@@ -28,6 +28,49 @@ export function createSupabaseClient(): SupabaseClient {
 }
 
 // ─────────────────────────────────────────────
+// Lumyn Pro entitlement
+// ─────────────────────────────────────────────
+
+export type LumynEntitlement = {
+  lumyn_pro: boolean
+  lumyn_pro_until: string | null
+  lumyn_messages_used: number
+}
+
+export async function getUserEntitlement(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<LumynEntitlement> {
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('lumyn_pro, lumyn_pro_until, lumyn_messages_used')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error || !data) {
+    // No profile row → treat as free tier, 0 messages used
+    return { lumyn_pro: false, lumyn_pro_until: null, lumyn_messages_used: 0 }
+  }
+
+  return {
+    lumyn_pro: data.lumyn_pro ?? false,
+    lumyn_pro_until: data.lumyn_pro_until ?? null,
+    lumyn_messages_used: data.lumyn_messages_used ?? 0,
+  }
+}
+
+/**
+ * Single entitlement resolver — use everywhere, never duplicate this logic.
+ */
+export function resolveLumynEntitlement(entitlement: LumynEntitlement): boolean {
+  return (
+    entitlement.lumyn_pro &&
+    (entitlement.lumyn_pro_until === null ||
+      new Date(entitlement.lumyn_pro_until) > new Date())
+  )
+}
+
+// ─────────────────────────────────────────────
 // Conversations
 // ─────────────────────────────────────────────
 

--- a/supabase/functions/lumyn-chat/orchestrator.ts
+++ b/supabase/functions/lumyn-chat/orchestrator.ts
@@ -21,6 +21,8 @@ import {
   closeStaleConversations,
   upsertClaim,
   deprecateClaim,
+  getUserEntitlement,
+  resolveLumynEntitlement,
 } from './db.ts'
 
 import {
@@ -114,8 +116,57 @@ export async function runOrchestrator(params: {
   mode?: LumynMode
   vyberologyContext: LumynInput[]
 }): Promise<ChatResponse> {
-  const { supabase, userId, message, vyberologyContext } = params
-  const mode: LumynMode = params.mode ?? 'reflect'
+  const { supabase, userId, message } = params
+
+  // ── Entitlement check ─────────────────────────────────────
+  const entitlement = await getUserEntitlement(supabase, userId)
+  const isPro = resolveLumynEntitlement(entitlement)
+
+  if (!isPro) {
+    // Atomic free-message increment — returns null if limit hit
+    const { data: newCount } = await supabase.rpc('lumyn_increment_free_messages', {
+      p_user_id: userId,
+    })
+
+    if (newCount === null) {
+      // Paywall hit — log event and return paywall response
+      await logSafetyEvent(supabase, {
+        user_id: userId,
+        event_type: 'paywall_hit',
+        trigger_source: 'policy',
+        details: {
+          messages_used: entitlement.lumyn_messages_used,
+          mode_requested: params.mode ?? 'reflect',
+        },
+      })
+
+      return {
+        conversationId: params.conversationId ?? 'no-conversation',
+        message: {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          content: '',
+          created_at: new Date().toISOString(),
+        },
+        mode: 'reflect',
+        classification: { intent: 'explore', emotion: 'neutral', domain: 'general' },
+        client_directives: { crisis_banner: false, anchor_active: false },
+        paywall: true,
+      }
+    }
+  }
+
+  // ── Mode coercion (declared AFTER isPro is available) ──────
+  const mode: LumynMode = !isPro ? 'reflect' : (params.mode ?? 'reflect')
+
+  // ── Strip context for free users ───────────────────────────
+  const vyberologyContext = isPro
+    ? params.vyberologyContext
+    : params.vyberologyContext
+        ? params.vyberologyContext.filter(
+            (i: { label: string }) => i.label !== 'ReadingHistory' && i.label !== 'UserProfile'
+          )
+        : []
 
   // ── Step 1: Rate limit check ──────────────────────────────
   const rateLimits = await upsertRateLimit(supabase, userId)
@@ -311,64 +362,67 @@ export async function runOrchestrator(params: {
     tokens_out: tokensOut,
   })
 
-  // Process memorable moments
-  await processMemorableMoments(
-    userId,
-    conversationId,
-    llmData.memorable_moments,
-    [...sessionHistory, userMsg, assistantMsg],
-    supabase
-  )
+  // Memory writes — Pro only
+  if (isPro) {
+    // Process memorable moments
+    await processMemorableMoments(
+      userId,
+      conversationId,
+      llmData.memorable_moments,
+      [...sessionHistory, userMsg, assistantMsg],
+      supabase
+    )
 
-  // Process memory suggestions → upsert/deprecate claims + log ops
-  const memoryOps: InsertMemoryOpData[] = []
-  for (const suggestion of llmData.memory_suggestions) {
-    try {
-      if (suggestion.op === 'create' || suggestion.op === 'update') {
-        const claim = await upsertClaim(supabase, userId, {
-          type: suggestion.type as never,
-          key: suggestion.key,
-          data: suggestion.data,
-          confidence: suggestion.confidence,
-          source_conversation_id: conversationId,
-        })
-        memoryOps.push({
-          user_id: userId,
-          message_id: assistantMsg.id,
-          op_type: suggestion.op,
-          target_claim_id: claim.id,
-          target_desc: suggestion.key,
-          reason: suggestion.reason,
-        })
-      } else if (suggestion.op === 'deprecate') {
-        // Find claim by key and deprecate
-        const existing = claims.find((c) => c.key === suggestion.key)
-        if (existing) {
-          await deprecateClaim(supabase, existing.id)
+    // Process memory suggestions → upsert/deprecate claims + log ops
+    const memoryOps: InsertMemoryOpData[] = []
+    for (const suggestion of llmData.memory_suggestions) {
+      try {
+        if (suggestion.op === 'create' || suggestion.op === 'update') {
+          const claim = await upsertClaim(supabase, userId, {
+            type: suggestion.type as never,
+            key: suggestion.key,
+            data: suggestion.data,
+            confidence: suggestion.confidence,
+            source_conversation_id: conversationId,
+          })
           memoryOps.push({
             user_id: userId,
             message_id: assistantMsg.id,
-            op_type: 'deprecate',
-            target_claim_id: existing.id,
+            op_type: suggestion.op,
+            target_claim_id: claim.id,
             target_desc: suggestion.key,
             reason: suggestion.reason,
           })
+        } else if (suggestion.op === 'deprecate') {
+          // Find claim by key and deprecate
+          const existing = claims.find((c) => c.key === suggestion.key)
+          if (existing) {
+            await deprecateClaim(supabase, existing.id)
+            memoryOps.push({
+              user_id: userId,
+              message_id: assistantMsg.id,
+              op_type: 'deprecate',
+              target_claim_id: existing.id,
+              target_desc: suggestion.key,
+              reason: suggestion.reason,
+            })
+          }
         }
+      } catch {
+        // Don't fail the response on memory write errors
       }
-    } catch {
-      // Don't fail the response on memory write errors
     }
-  }
 
-  if (memoryOps.length > 0) {
-    await logMemoryOps(supabase, memoryOps)
+    if (memoryOps.length > 0) {
+      await logMemoryOps(supabase, memoryOps)
+    }
   }
 
   // Close stale conversations async (non-blocking)
   closeStaleConversations(supabase, userId).catch(() => {})
 
   // Also trigger summary generation if conversation is being closed
-  if (conversation.status === 'closed') {
+  if (conversation.status === 'closed' && isPro) {
     generateConversationSummary(conversationId, supabase).catch(() => {})
   }
 

--- a/supabase/functions/lumyn-chat/orchestrator.ts
+++ b/supabase/functions/lumyn-chat/orchestrator.ts
@@ -124,11 +124,14 @@ export async function runOrchestrator(params: {
 
   if (!isPro) {
     // Atomic free-message increment — returns null if limit hit
-    const { data: newCount } = await supabase.rpc('lumyn_increment_free_messages', {
+    const { data: newCount, error: rpcError } = await supabase.rpc('lumyn_increment_free_messages', {
       p_user_id: userId,
     })
 
-    if (newCount === null) {
+    if (rpcError) {
+      // Fail open on transient DB error — don't block user with paywall
+      console.error('lumyn_increment_free_messages RPC error:', rpcError.message)
+    } else if (newCount === null) {
       // Paywall hit — log event and return paywall response
       await logSafetyEvent(supabase, {
         user_id: userId,

--- a/supabase/functions/lumyn-chat/types.ts
+++ b/supabase/functions/lumyn-chat/types.ts
@@ -57,7 +57,7 @@ export type LumynMemoryOp = 'create' | 'update' | 'deprecate' | 'ignore' | 'retr
 // Safety
 // ─────────────────────────────────────────────
 
-export type LumynSafetyEvent = 'crisis_detected' | 'overreach_blocked' | 'escalation'
+export type LumynSafetyEvent = 'crisis_detected' | 'overreach_blocked' | 'escalation' | 'paywall_hit'
 
 // ─────────────────────────────────────────────
 // Shared input type (matches client lumynContext.ts output)
@@ -263,6 +263,7 @@ export type ChatResponse = {
     crisis_banner: boolean
     anchor_active: boolean
   }
+  paywall?: true
 }
 
 // ─────────────────────────────────────────────

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -289,7 +289,7 @@ async function handleSubscriptionDeleted(
   const customer = await stripe.customers.retrieve(subscription.customer as string)
   const userId = (customer as Stripe.Customer).metadata?.supabase_user_id
   if (!userId) {
-    console.error('No supabase_user_id in customer metadata on deletion')
+    console.error('CRITICAL: No supabase_user_id in customer metadata on subscription deletion — Lumyn Pro revocation skipped. Subscription ID:', subscription.id, 'Customer ID:', subscription.customer)
     return
   }
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -263,6 +263,11 @@ async function handleSubscriptionUpdate(
   });
 
   console.log(`Updated subscription ${subscription.id} for user ${userId}`);
+
+  // Grant/confirm Lumyn Pro if this is the Pro subscription
+  if (isLumynProPrice(subscription) && subscription.status === 'active') {
+    await setLumynPro(supabase, userId, true, null)
+  }
 }
 
 async function handleSubscriptionDeleted(
@@ -279,6 +284,21 @@ async function handleSubscriptionDeleted(
     .eq('stripe_subscription_id', subscription.id);
 
   console.log(`Deleted subscription ${subscription.id}`);
+
+  // Resolve userId via customer lookup (mirrors handleSubscriptionUpdate)
+  const customer = await stripe.customers.retrieve(subscription.customer as string)
+  const userId = (customer as Stripe.Customer).metadata?.supabase_user_id
+  if (!userId) {
+    console.error('No supabase_user_id in customer metadata on deletion')
+    return
+  }
+
+  // Revoke Lumyn Pro if this is the Pro subscription
+  if (isLumynProPrice(subscription)) {
+    const proUntil = new Date(subscription.current_period_end * 1000).toISOString()
+    await setLumynPro(supabase, userId, false, proUntil)
+    console.log(`Revoked Lumyn Pro for user ${userId}, until ${proUntil}`)
+  }
 }
 
 /**
@@ -303,4 +323,33 @@ function calculateCreditsFromAmount(amountCents: number): number {
   };
 
   return amounts[amountCents] || 0;
+}
+
+/**
+ * Returns true if any subscription line item matches the Lumyn Pro price.
+ * Checks all items (not just [0]) for robustness.
+ */
+function isLumynProPrice(subscription: Stripe.Subscription): boolean {
+  const lumynProPriceId = Deno.env.get('LUMYN_PRO_STRIPE_PRICE_ID')
+  if (!lumynProPriceId) return false
+  return subscription.items.data.some(item => item.price.id === lumynProPriceId)
+}
+
+/**
+ * Set or clear Lumyn Pro entitlement on user_profiles.
+ * Uses upsert so it is safe if the profile row doesn't exist yet.
+ * Only touches lumyn_pro and lumyn_pro_until — other columns are unaffected.
+ */
+async function setLumynPro(
+  supabase: any,
+  userId: string,
+  isPro: boolean,
+  proUntil: string | null
+): Promise<void> {
+  const { error } = await supabase.from('user_profiles').upsert({
+    user_id: userId,
+    lumyn_pro: isPro,
+    lumyn_pro_until: proUntil,
+  }, { onConflict: 'user_id' })
+  if (error) console.error('setLumynPro failed:', error.message)
 }

--- a/supabase/functions/validate-iap-receipt/index.ts
+++ b/supabase/functions/validate-iap-receipt/index.ts
@@ -12,6 +12,9 @@ const PRODUCT_CREDITS: Record<string, number> = {
   'com.vyberology.deep_attunement': 1,
 };
 
+// Subscription product IDs that grant Lumyn Pro
+const SUBSCRIPTION_PRODUCTS = new Set(['com.vyberology.lumyn_pro'])
+
 serve(async (req) => {
   const authHeader = req.headers.get('Authorization');
   if (!WEBHOOK_SECRET || authHeader !== `Bearer ${WEBHOOK_SECRET}`) {
@@ -85,6 +88,37 @@ serve(async (req) => {
           tier: productId,
         });
       }
+    }
+
+    // Handle Lumyn Pro subscription grants
+    if (
+      (eventType === 'INITIAL_PURCHASE' || eventType === 'RENEWAL' || eventType === 'REACTIVATION') &&
+      SUBSCRIPTION_PRODUCTS.has(event.product_id) &&
+      appUserId
+    ) {
+      const { error } = await supabase.from('user_profiles').upsert({
+        user_id: appUserId,
+        lumyn_pro: true,
+        lumyn_pro_until: null,
+      }, { onConflict: 'user_id' })
+      if (error) console.error('Failed to grant Lumyn Pro (IAP):', error.message)
+      else console.log(`Granted Lumyn Pro to user ${appUserId} via ${eventType}`)
+    }
+
+    // Handle Lumyn Pro subscription cancellations
+    if (
+      eventType === 'EXPIRATION' &&
+      SUBSCRIPTION_PRODUCTS.has(event.product_id) &&
+      appUserId
+    ) {
+      const { error } = await supabase.from('user_profiles').upsert({
+        user_id: appUserId,
+        lumyn_pro: false,
+        lumyn_pro_until: event.expiration_at_ms
+          ? new Date(event.expiration_at_ms).toISOString()
+          : new Date().toISOString(),
+      }, { onConflict: 'user_id' })
+      if (error) console.error('Failed to revoke Lumyn Pro (IAP):', error.message)
     }
 
     // Handle refunds

--- a/supabase/functions/validate-iap-receipt/index.ts
+++ b/supabase/functions/validate-iap-receipt/index.ts
@@ -121,8 +121,8 @@ serve(async (req) => {
       if (error) console.error('Failed to revoke Lumyn Pro (IAP):', error.message)
     }
 
-    // Handle refunds
-    if (eventType === 'CANCELLATION' && event.cancel_reason === 'CUSTOMER_SUPPORT') {
+    // Handle refunds (skip credit deduction for subscription products)
+    if (eventType === 'CANCELLATION' && event.cancel_reason === 'CUSTOMER_SUPPORT' && !SUBSCRIPTION_PRODUCTS.has(event.product_id)) {
       if (appUserId) {
         await supabase.from('credit_transactions').insert({
           user_id: appUserId,

--- a/supabase/migrations/20260319000000_lumyn_pro.sql
+++ b/supabase/migrations/20260319000000_lumyn_pro.sql
@@ -1,0 +1,44 @@
+-- supabase/migrations/20260319000000_lumyn_pro.sql
+
+-- Add Lumyn Pro entitlement columns to user_profiles
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS lumyn_pro            BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS lumyn_pro_until      TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS lumyn_messages_used  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS lumyn_last_message_at TIMESTAMPTZ;
+
+-- Atomic free-message increment
+-- Returns new count, or NULL if limit already hit (0 rows updated)
+CREATE OR REPLACE FUNCTION lumyn_increment_free_messages(p_user_id UUID)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_new_count INTEGER;
+BEGIN
+  UPDATE user_profiles
+    SET lumyn_messages_used = lumyn_messages_used + 1
+    WHERE user_id = p_user_id
+      AND lumyn_messages_used < 10
+      AND lumyn_pro = false
+    RETURNING lumyn_messages_used INTO v_new_count;
+  RETURN v_new_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION lumyn_increment_free_messages(UUID) TO authenticated;
+
+-- Seed Lumyn Pro product + price
+-- Replace placeholder IDs with real Stripe IDs before deploy
+INSERT INTO products (stripe_product_id, name, description, active)
+VALUES ('prod_lumyn_pro', 'Lumyn Pro', 'Unlimited Lumyn conversations with full memory and all modes', true)
+ON CONFLICT (stripe_product_id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description;
+
+INSERT INTO prices (product_id, stripe_price_id, currency, unit_amount, interval, interval_count, active)
+VALUES (
+  (SELECT id FROM products WHERE stripe_product_id = 'prod_lumyn_pro'),
+  'price_lumyn_pro_monthly',
+  'usd',
+  1497,
+  'month',
+  1,
+  true
+)
+ON CONFLICT (stripe_price_id) DO UPDATE SET unit_amount = EXCLUDED.unit_amount, active = EXCLUDED.active;

--- a/supabase/migrations/20260319000000_lumyn_pro.sql
+++ b/supabase/migrations/20260319000000_lumyn_pro.sql
@@ -26,15 +26,14 @@ $$;
 GRANT EXECUTE ON FUNCTION lumyn_increment_free_messages(UUID) TO authenticated;
 
 -- Seed Lumyn Pro product + price
--- Replace placeholder IDs with real Stripe IDs before deploy
 INSERT INTO products (stripe_product_id, name, description, active)
-VALUES ('prod_lumyn_pro', 'Lumyn Pro', 'Unlimited Lumyn conversations with full memory and all modes', true)
+VALUES ('prod_UBa8Sm2LE6AtYN', 'Lumyn Pro', 'Unlimited Lumyn conversations with full memory and all modes', true)
 ON CONFLICT (stripe_product_id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description;
 
 INSERT INTO prices (product_id, stripe_price_id, currency, unit_amount, interval, interval_count, active)
 VALUES (
-  (SELECT id FROM products WHERE stripe_product_id = 'prod_lumyn_pro'),
-  'price_lumyn_pro_monthly',
+  (SELECT id FROM products WHERE stripe_product_id = 'prod_UBa8Sm2LE6AtYN'),
+  'price_1TDCy4KQHOT2DNgNv5aINeKq',
   'usd',
   1497,
   'month',


### PR DESCRIPTION
## Summary

- Adds Lumyn Pro as a \$14.97/month recurring subscription via Stripe
- Free tier: 10 lifetime messages, reflect mode only, no memory, no reading history
- Pro tier: unlimited conversations, all four modes, full memory persistence, thread history, reading history in context
- Soft paywall: inline `LumynPaywallCard` injected when free limit is hit
- Thread switcher UI with conversation history drawer in `LumynChatFab`

## What Changed

- **DB migration** (`20260319000000_lumyn_pro.sql`): adds `lumyn_pro`, `lumyn_pro_until`, `lumyn_messages_used`, `lumyn_last_message_at` to `user_profiles`; adds `lumyn_increment_free_messages` atomic RPC; seeds Lumyn Pro product + price rows
- **Stripe webhook**: `isLumynProPrice`, `setLumynPro` helpers; grants/revokes entitlement on subscription lifecycle events
- **Checkout**: conditional `subscription_data` / `payment_intent_data` for lumyn-pro vs other tiers
- **Orchestrator**: entitlement gate before rate limit; free-tier mode coercion, context stripping, memory write gating; `paywall: true` response field
- **IAP**: `purchaseSubscription` path for native (web-first, UI hidden until device tested)
- **Client**: `useLumynEntitlement` hook, `LumynThreadList`, `LumynPaywallCard`, wired into `LumynChatFab` and `PaymentSuccess`

## Before Going Live (Task 12)

- [ ] Create real Stripe product + price in Stripe dashboard
- [ ] Replace placeholder IDs in migration (`prod_lumyn_pro`, `price_lumyn_pro_monthly`)
- [ ] Set `VITE_LUMYN_PRO_PRICE_ID` in Vercel env
- [ ] Set `LUMYN_PRO_STRIPE_PRICE_ID` in Supabase secrets
- [ ] Deploy edge functions: `lumyn-chat stripe-webhook create-checkout-session validate-iap-receipt`
- [ ] Run `supabase db push` to apply migration
- [ ] Smoke test: send 11 messages as free user, verify paywall response on 11th

## Test Plan

- [ ] Free user sends 10 messages — all succeed
- [ ] Free user sends 11th message — `paywall: true` returned, `LumynPaywallCard` renders
- [ ] Free user mode is coerced to `reflect` regardless of selection
- [ ] Stripe checkout for `lumyn-pro` creates a subscription (not one-time payment)
- [ ] Webhook `customer.subscription.updated` sets `lumyn_pro = true` on `user_profiles`
- [ ] Webhook `customer.subscription.deleted` sets `lumyn_pro = false` with `lumyn_pro_until`
- [ ] `/payment/success?upgraded=true&tier=lumyn-pro` shows Pro content + welcome toast
- [ ] Thread switcher shows 1 thread for free, up to 10 for Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)